### PR TITLE
Format intermal sample ids with hyphens for readability

### DIFF
--- a/sample_metadata/README.md
+++ b/sample_metadata/README.md
@@ -10,10 +10,10 @@ There are no docs at the moment, but as a rough guide, you could do the followin
 ```python
 from sample_metadata.api.samples_api import SamplesApi
 sapi = SamplesApi()
-sample = sapi.get_sample_by_external_id('dev', 'CPG0001')
+sample = sapi.get_sample_by_external_id('dev', 'CPG-109')
 print(sample)
 # {'active': True,
-#  'external_id': 'CPG0001',
+#  'external_id': 'CPG-109',
 #  'id': 1,
 #  'meta': {'Volume (ul)': '100'},
 #  'participant_id': None,

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -1,21 +1,20 @@
-from sample_metadata.apis import SampleApi, AnalysisApi
-from sample_metadata.model.new_sample import NewSample
-from sample_metadata.model.analysis_model import AnalysisModel
-from sample_metadata.models import AnalysisStatus, AnalysisType, SampleType
+from sample_metadata.api import SampleApi, AnalysisApi
+from sample_metadata.models.new_sample import NewSample
+from sample_metadata.models.analysis_model import AnalysisModel
 
 sapi = SampleApi()
 aapi = AnalysisApi()
 
 new_sample = NewSample(
-    external_id='CPG0007', type=SampleType('blood'), meta={'other-meta': 'value'}
+    external_id='CPG-109', type='blood', meta={'other-meta': 'value'}
 )
 sample_id = sapi.create_new_sample('dev', new_sample)
 
 analysis = AnalysisModel(
     sample_ids=[sample_id],
-    type=AnalysisType('gvcf'),
+    type='gvcf',
     output='gs://output-path',
-    status=AnalysisStatus('completed'),
+    status='completed',
 )
 analysis_id = aapi.create_new_analysis('dev', analysis)
 


### PR DESCRIPTION
What do you think about additionally formatting sample numbers with hyphens for readability? CPG141243 -> CPG-1412-43. 
I  usually find it to improve the experience when doing the data analysis.

(We could look into turning IDs into random meaningful expressions - similar to the docker container names (`nostalgic_stallman` and `focused_yonath`), that would improve communicating samples even further. Or even follow Loic's suggestion and include some real metadata into the IDs, like the abbreviated dataset name.)