### PR TITLE
Genericise ingestor

### DIFF
--- a/db/python/tables/sequencing.py
+++ b/db/python/tables/sequencing.py
@@ -126,7 +126,7 @@ ORDER by id
         # hopefully there aren't too many
         sequences = await self.connection.fetch_all(_query, {'sample_ids': sample_ids})
         sample_id_to_seq_id = {}
-        for sample_id, seqs in groupby(sequences, lambda seq: seq[0]):
+        for sample_id, seqs in groupby(sequences, lambda seq: seq['sample_id']):
             sample_id_to_seq_id[sample_id] = list(seqs)[-1]['id']  # get last one
 
         return sample_id_to_seq_id

--- a/scripts/parse_tobwgs_csv.py
+++ b/scripts/parse_tobwgs_csv.py
@@ -17,11 +17,6 @@ logger = logging.getLogger(__file__)
 logger.addHandler(logging.StreamHandler())
 logger.setLevel(logging.INFO)
 
-FASTQ_EXTENSIONS = ('.fq', '.fastq', '.fq.gz', '.fastq.gz')
-BAM_EXTENSIONS = ('.bam',)
-CRAM_EXTENSIONS = ('.cram',)
-VCFGZ_EXTENSIONS = ('.vcf.gz',)
-
 
 class Columns:
     """Column keys for VCGS manifest"""

--- a/scripts/parse_tobwgs_csv.py
+++ b/scripts/parse_tobwgs_csv.py
@@ -70,8 +70,8 @@ class Columns:
         ]
 
 
-class VcgsManifestParser(GenericParser):
-    """Parser for VCGS manifest"""
+class TobWgsParser(GenericParser):
+    """Parser for TOBWgs manifest"""
 
     def get_sample_id(self, row: Dict[str, any]):
         return row[Columns.SAMPLE_NAME]

--- a/scripts/parse_tobwgs_csv.py
+++ b/scripts/parse_tobwgs_csv.py
@@ -133,6 +133,7 @@ class TobWgsParser(GenericParser):
         collapsed_sequence_meta['gvcf_type'] = variants_type
 
         collapsed_sequence_meta['project'] = self.project
+        collapsed_sequence_meta['batch'] = batch_number
 
         return collapsed_sequence_meta
 

--- a/scripts/parse_tobwgs_csv.py
+++ b/scripts/parse_tobwgs_csv.py
@@ -1,9 +1,8 @@
 # pylint: disable=too-many-instance-attributes,too-many-locals
 import logging
 import os
-import re
 from io import StringIO
-from typing import Dict
+from typing import Dict, Optional
 
 import click
 
@@ -11,9 +10,8 @@ from sample_metadata.model.sample_type import SampleType
 from sample_metadata.model.sequence_status import SequenceStatus
 from sample_metadata.model.sequence_type import SequenceType
 
-from .parser import GenericParser, GROUPED_ROW
+from scripts.parser import GenericParser, GroupedRow
 
-rmatch = re.compile(r'_[Rr]\d')
 
 logger = logging.getLogger(__file__)
 logger.addHandler(logging.StreamHandler())
@@ -28,122 +26,134 @@ VCFGZ_EXTENSIONS = ('.vcf.gz',)
 class Columns:
     """Column keys for VCGS manifest"""
 
-    PHS_ACCESSION = 'phs_accession'
-    SAMPLE_NAME = 'sample_name'
-    LIBRARY_ID = 'library_ID'
-    TITLE = 'title'
-    LIBRARY_STRATEGY = 'library_strategy'
-    LIBRARY_SOURCE = 'library_source'
-    LIBRARY_SELECTION = 'library_selection'
-    LIBRARY_LAYOUT = 'library_layout'
-    PLATFORM = 'platform'
-    INSTRUMENT_MODEL = 'instrument_model'
-    DESIGN_DESCRIPTION = 'design_description'
-    REFERENCE_GENOME_ASSEMBLY = 'reference_genome_assembly'
-    ALIGNMENT_SOFTWARE = 'alignment_software'
-    FORWARD_READ_LENGTH = 'forward_read_length'
-    REVERSE_READ_LENGTH = 'reverse_read_length'
-    FILETYPE = 'filetype'
-    FILENAME = 'filename'
+    KCCG_ID = 'sample.id'
+    SAMPLE_NAME = 'sample.sample_name'
+    FLOWCELL_LANE = 'sample.flowcell_lane'
+    LIBRARY_ID = 'sample.library_id'
+    PLATFORM = 'sample.platform'
+    CENTRE = 'sample.centre'
+    REFERENCE_GENOME = 'sample.reference_genome'
+    FREEMIX = 'raw_data.FREEMIX'
+    PCT_CHIMERAS = 'raw_data.PCT_CHIMERAS'
+    PERCENT_DUPLICATION = 'raw_data.PERCENT_DUPLICATION'
+    MEDIAN_INSERT_SIZE = 'raw_data.MEDIAN_INSERT_SIZE'
+    MEDIAN_COVERAGE = 'raw_data.MEDIAN_COVERAGE'
+    BATCH_NAME = 'batch.batch_name'
+    SAMPLE_COUNT = 'batch.sample_count'
 
     @staticmethod
     def sequence_columns():
         """Columns that will be put into sequence.meta"""
         return [
+            Columns.FLOWCELL_LANE,
             Columns.LIBRARY_ID,
-            Columns.LIBRARY_STRATEGY,
-            Columns.LIBRARY_SOURCE,
-            Columns.LIBRARY_SELECTION,
-            Columns.LIBRARY_LAYOUT,
             Columns.PLATFORM,
-            Columns.INSTRUMENT_MODEL,
-            Columns.DESIGN_DESCRIPTION,
-            Columns.FORWARD_READ_LENGTH,
-            Columns.REVERSE_READ_LENGTH,
-        ]
-
-    @staticmethod
-    def sample_columns():
-        """Columns that will be put into sample.meta"""
-        return [
-            Columns.PHS_ACCESSION,
+            Columns.CENTRE,
+            Columns.REFERENCE_GENOME,
+            Columns.FREEMIX,
+            Columns.PCT_CHIMERAS,
+            Columns.PERCENT_DUPLICATION,
+            Columns.MEDIAN_INSERT_SIZE,
+            Columns.MEDIAN_COVERAGE,
         ]
 
 
 class TobWgsParser(GenericParser):
     """Parser for TOBWgs manifest"""
 
+    buckets = {}
+
+    def get_gvcf_path(self, sample_id: str, batch_number: int) -> Optional[str]:
+        """
+        GVCFs can be in a few places, so please find it from search locations
+        """
+        filename = f'{sample_id}.g.vcf.gz'
+        dirs = [
+            'gs://cpg-tob-wgs-main-upload/',
+            f'gs://cpg-tob-wgs-main/gvcf/batch{batch_number}/',
+        ]
+        for base in dirs:
+            fpath = os.path.join(base, filename)
+            if self.file_exists(fpath):
+                return fpath
+
+        return None
+
+    def get_cram_path(self, sample_id: str, batch_number: int) -> Optional[str]:
+        """
+        CRAMs can be in a few places, so please find it from search locations
+        """
+        filename = f'{sample_id}.cram'
+        dirs = [
+            'gs://cpg-tob-wgs-main-upload/',
+            f'gs://cpg-tob-wgs-archive/cram/batch{batch_number}/',
+        ]
+        for base in dirs:
+            fpath = os.path.join(base, filename)
+            if self.file_exists(fpath):
+                return fpath
+
+        return None
+
     def get_sample_id(self, row: Dict[str, any]):
+        """Get external sample ID from row"""
         return row[Columns.SAMPLE_NAME]
 
-    def get_sample_meta(self, sample_id: str, row: GROUPED_ROW):
-        if isinstance(row, list):
-            collapsed_sample_meta = {
-                col: ','.join(set(r[col] for r in row))
-                for col in Columns.sample_columns()
-            }
-            reads, reads_type = self.parse_reads([r[Columns.FILENAME] for r in row])
-        else:
-            collapsed_sample_meta = {col: row[col] for col in Columns.sample_columns()}
-            reads, reads_type = self.parse_reads([row[Columns.FILENAME]])
-
-        collapsed_sample_meta['reads'] = reads
-        collapsed_sample_meta['reads_type'] = reads_type
-        collapsed_sample_meta['project'] = self.project
+    def get_sample_meta(self, sample_id: str, row: GroupedRow):
+        """Get sample-metadata from row"""
+        collapsed_sample_meta = {}
 
         return collapsed_sample_meta
 
-    def get_sequence_meta(self, sample_id: str, row: GROUPED_ROW):
-        return {
-            col: ','.join(set(r[col] for r in row))
-            for col in Columns.sequence_columns()
-        }
+    def get_sequence_meta(self, sample_id: str, row: GroupedRow):
+        """Get sequence-metadata from row"""
 
-    def get_sequence_type(self, sample_id: str, row: GROUPED_ROW) -> SequenceType:
+        if isinstance(row, list):
+            collapsed_sequence_meta = {
+                col: ','.join(set(r[col] for r in row))
+                for col in Columns.sequence_columns()
+            }
+        else:
+            collapsed_sequence_meta = {
+                col: row[col] for col in Columns.sequence_columns()
+            }
+
+        batch_number = int(row[Columns.BATCH_NAME][-3:])
+
+        gvcf, variants_type = self.parse_file(
+            [self.get_gvcf_path(sample_id, batch_number)]
+        )
+        reads, reads_type = self.parse_file(
+            [self.get_cram_path(sample_id, batch_number)]
+        )
+
+        if len(gvcf) == 1:
+            gvcf = gvcf[0]
+        if len(reads) == 1:
+            reads = reads[0]
+
+        collapsed_sequence_meta['reads'] = reads
+        collapsed_sequence_meta['reads_type'] = reads_type
+        collapsed_sequence_meta['gvcf'] = gvcf
+        collapsed_sequence_meta['gvcf_type'] = variants_type
+
+        collapsed_sequence_meta['project'] = self.project
+
+        return collapsed_sequence_meta
+
+    def get_sequence_type(self, sample_id: str, row: GroupedRow) -> SequenceType:
         """
         Parse sequencing type (wgs / single-cell, etc)
         """
         # filter false-y values
-        if not isinstance(row, list):
-            return SequenceType(row[Columns.LIBRARY_STRATEGY])
-        else:
-            types = list(
-                set(
-                    r[Columns.LIBRARY_STRATEGY]
-                    for r in row
-                    if r[Columns.LIBRARY_STRATEGY]
-                )
-            )
-            if len(types) <= 0:
-                if (
-                    self.default_sequencing_type is None
-                    or self.default_sequencing_type.lower() == 'none'
-                ):
-                    raise ValueError(
-                        f"Couldn't detect sequence type for sample {sample_id}, and "
-                        'no default was available.'
-                    )
-                return self.default_sequencing_type
-            if len(types) > 1:
-                raise ValueError(
-                    f'Multiple library types for same sample {sample_id}, '
-                    f'maybe there are multiples types of sequencing in the same '
-                    f'manifest? If so, please raise an issue with mfranklin to '
-                    f'change the groupby to include {Columns.LIBRARY_STRATEGY}.'
-                )
+        return self.default_sequence_type
 
-            type_ = types[0].lower()
-            if type_ == 'wgs':
-                return SequenceType('wgs')
-            if type_ in ('single-cell', 'ss'):
-                return SequenceType('single-cell')
-
-            raise ValueError(f'Unrecognised sequencing type {type_}')
-
-    def get_sample_type(self, sample_id: str, row: GROUPED_ROW) -> SampleType:
+    def get_sample_type(self, sample_id: str, row: GroupedRow) -> SampleType:
+        """Get sample type"""
         return self.default_sample_type
 
-    def get_sequence_status(self, sample_id: str, row: GROUPED_ROW) -> SequenceStatus:
+    def get_sequence_status(self, sample_id: str, row: GroupedRow) -> SequenceStatus:
+        """Get sequence status from row"""
         return SequenceStatus('uploaded')
 
     @staticmethod
@@ -162,7 +172,7 @@ class TobWgsParser(GenericParser):
         else:
             manifest_filename = manifest
 
-        parser = VcgsManifestParser(
+        parser = TobWgsParser(
             path_prefix,
             project=project,
             sample_metadata_project=sample_metadata_project,
@@ -186,6 +196,7 @@ class TobWgsParser(GenericParser):
 )
 @click.option('--default-sample-type', default='blood')
 @click.option('--default-sequence-type', default='wgs')
+@click.option('--path-prefix', default=None)
 @click.argument('manifests', nargs=-1)
 def main(
     manifests,
@@ -193,17 +204,19 @@ def main(
     sample_metadata_project,
     default_sample_type='blood',
     default_sequence_type='wgs',
+    path_prefix=None,
 ):
     """Run script from CLI arguments"""
 
     for manifest in manifests:
         logger.info(f'Importing {manifest}')
-        resp = VcgsManifestParser.from_manifest_path(
+        resp = TobWgsParser.from_manifest_path(
             manifest=manifest,
             project=project,
             sample_metadata_project=sample_metadata_project,
             default_sample_type=default_sample_type,
             default_sequence_type=default_sequence_type,
+            path_prefix=path_prefix,
         )
         print(resp)
 

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -201,9 +201,7 @@ class GenericParser:
         for external_sample_id in sample_map:
             logger.info(f'Preparing {external_sample_id}')
             rows = sample_map[external_sample_id]
-            # TODO: remove this
-            if external_sample_id not in external_id_map:
-                continue
+
             if len(rows) == 1:
                 rows = rows[0]
             # now we have sample / sequencing meta across 4 different rows, so collapse them
@@ -246,18 +244,18 @@ class GenericParser:
 
         logger.info(f'Adding {len(samples_to_add)} samples to SM-DB database')
         ext_sample_to_internal_id = {}
-        # for new_sample in samples_to_add:
-        #     sample_id = sapi.create_new_sample(
-        #         project=self.sample_metadata_project, new_sample=new_sample
-        #     )
-        #     ext_sample_to_internal_id[new_sample.external_id] = sample_id
-        #
-        # for sample_id, sequences_to_add in sequencing_to_add.items():
-        #     for seq in sequences_to_add:
-        #         seq.sample_id = ext_sample_to_internal_id[sample_id]
-        #         seqapi.create_new_sequence(
-        #             project=self.sample_metadata_project, new_sequence=seq
-        #         )
+        for new_sample in samples_to_add:
+            sample_id = sapi.create_new_sample(
+                project=self.sample_metadata_project, new_sample=new_sample
+            )
+            ext_sample_to_internal_id[new_sample.external_id] = sample_id
+
+        for sample_id, sequences_to_add in sequencing_to_add.items():
+            for seq in sequences_to_add:
+                seq.sample_id = ext_sample_to_internal_id[sample_id]
+                seqapi.create_new_sequence(
+                    project=self.sample_metadata_project, new_sequence=seq
+                )
 
         logger.info(f'Updating {len(samples_to_update)} samples')
         for internal_sample_id, sample_update in samples_to_update.items():

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -393,14 +393,14 @@ class GenericParser:
         """
         secondaries = []
         for sec in potential_secondary_patterns:
-            sec_file = apply_secondary_file_format_to_filename(filename, sec)
+            sec_file = _apply_secondary_file_format_to_filename(filename, sec)
             if self.file_exists(sec_file):
                 secondaries.append(self.create_file_object(sec_file))
 
         return secondaries
 
 
-def apply_secondary_file_format_to_filename(
+def _apply_secondary_file_format_to_filename(
     filepath: Optional[str], secondary_file: str
 ):
     """

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -1,0 +1,447 @@
+# pylint: disable=too-many-instance-attributes,too-many-locals
+import csv
+import logging
+import os
+import re
+from abc import abstractmethod
+from collections import defaultdict
+from io import StringIO
+from itertools import groupby
+from typing import List, Dict, Union, Optional, Tuple
+
+import click
+
+from sample_metadata.apis import SampleApi, SequenceApi
+from sample_metadata.model.new_sample import NewSample
+from sample_metadata.model.new_sequence import NewSequence
+from sample_metadata.model.sequence_status import SequenceStatus
+from sample_metadata.model.sequence_type import SequenceType
+from sample_metadata.model.sample_type import SampleType
+
+# from sample_metadata.model.sequence_update_model import SequenceUpdateModel
+from sample_metadata.model.sample_update_model import SampleUpdateModel
+
+logger = logging.getLogger(__file__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.INFO)
+
+FASTQ_EXTENSIONS = ('.fq', '.fastq', '.fq.gz', '.fastq.gz')
+BAM_EXTENSIONS = ('.bam',)
+CRAM_EXTENSIONS = ('.cram',)
+VCFGZ_EXTENSIONS = ('.vcf.gz',)
+
+GROUPED_ROW = Union[List[Dict[str, any]], Dict[str, any]]
+
+
+class GenericParser:
+    """Parser for VCGS manifest"""
+
+    def __init__(
+        self,
+        path_prefix: str,
+        sample_metadata_project: str,
+        project: str,
+        default_sequence_type='wgs',
+        default_sample_type='blood',
+    ):
+        super().__init__()
+
+        self.path_prefix = path_prefix
+
+        self.project = project
+        self.sample_metadata_project = sample_metadata_project
+
+        self.default_sequencing_type = default_sequence_type
+        self.default_sample_type = default_sample_type
+
+        # gs specific
+        self.bucket = None
+
+        self.client = None
+        self.bucket_client = None
+
+        if path_prefix.startswith('gs://'):
+            # pylint: disable=import-outside-toplevel
+            from google.cloud import storage
+
+            self.client = storage.Client()
+            path_components = path_prefix[5:].split('/')
+            self.bucket = path_components[0]
+            self.bucket_client = self.client.get_bucket(self.bucket)
+            self.path_prefix = '/'.join(path_components[1:])
+
+    def file_path(self, filename) -> str:
+        """
+        Get complete filepath of filename:
+        - Includes gs://{bucket} if relevant
+        - Includes path_prefix decided early on
+        """
+        if self.client and not filename.startswith('/'):
+            return os.path.join('gs://', self.bucket, self.path_prefix, filename)
+        return os.path.join(self.path_prefix, filename)
+
+    def file_contents(self, filename) -> str:
+        """Get contents of file (decoded as utf8)"""
+        path = os.path.join(self.path_prefix, filename)
+        if self.client and not filename.startswith('/'):
+            blob = self.bucket_client.get_blob(path)
+            return blob.download_as_string().decode()
+
+        with open(path) as f:
+            return f.read()
+
+    def file_exists(self, filename) -> bool:
+        """Determines whether a file exists"""
+        path = os.path.join(self.path_prefix, filename)
+        if self.client and not filename.startswith('/'):
+            blob = self.bucket_client.get_blob(path)
+            return blob is not None and blob.exists()
+
+        return os.path.exists(path)
+
+    def file_size(self, filename):
+        """Get size of file in bytes"""
+        path = os.path.join(self.path_prefix, filename)
+        if self.client and not filename.startswith('/'):
+            blob = self.bucket_client.get_blob(path)
+            return blob.size
+
+        return os.path.getsize(path)
+
+    @abstractmethod
+    def get_sample_id(self, row: Dict[str, any]):
+        pass
+
+    @abstractmethod
+    def get_sample_meta(self, sample_id: str, row: GROUPED_ROW):
+        pass
+
+    @abstractmethod
+    def get_sequence_meta(self, sample_id: str, row: GROUPED_ROW):
+        pass
+
+    @abstractmethod
+    def get_sample_type(self, sample_id: str, row: GROUPED_ROW) -> SampleType:
+        pass
+
+    @abstractmethod
+    def get_sequence_type(self, sample_id: str, row: GROUPED_ROW) -> SequenceType:
+        pass
+
+    @abstractmethod
+    def get_sequence_status(self, sample_id: str, row: GROUPED_ROW) -> SequenceStatus:
+        pass
+
+    def parse_manifest(self, file_pointer):
+        """
+        Parse manifest from iterable (file pointer / String.IO)
+        """
+        # a sample has many rows
+        sample_map = defaultdict(list)
+
+        reader = csv.DictReader(file_pointer, delimiter='\t')
+        for row in reader:
+            sample_id = self.get_sample_id(row)
+            sample_map[sample_id].append(row)
+
+        # now we can start adding!!
+        sapi = SampleApi()
+        seqapi = SequenceApi()
+
+        # determine if any samples exist
+        external_id_map = sapi.get_sample_id_map_by_external(
+            self.sample_metadata_project, list(sample_map.keys()), allow_missing=True
+        )
+
+        samples_to_add: List[NewSample] = []
+        # by external_sample_id
+        sequencing_to_add: Dict[str, List[NewSequence]] = defaultdict(list)
+
+        samples_to_update: Dict[str, SampleUpdateModel] = {}
+        # sequences_to_update: List[Dict] = []
+
+        for external_sample_id in sample_map:
+            logger.info(f'Preparing {external_sample_id}')
+            rows = sample_map[external_sample_id]
+            if len(rows) == 1:
+                rows = rows[0]
+            # now we have sample / sequencing meta across 4 different rows, so collapse them
+            collapsed_sequencing_meta = self.get_sequence_meta(external_sample_id, rows)
+            collapsed_sample_meta = self.get_sample_meta(external_sample_id, rows)
+            sample_type = self.get_sample_type(external_sample_id, rows)
+            sequence_status = self.get_sequence_status(external_sample_id, rows)
+
+            if external_sample_id in external_id_map:
+                # it already exists
+                cpgid = external_id_map[external_sample_id]
+                samples_to_update[cpgid] = SampleUpdateModel(
+                    meta=collapsed_sample_meta,
+                )
+            else:
+                samples_to_add.append(
+                    NewSample(
+                        external_id=external_sample_id,
+                        type=SampleType(self.default_sample_type),
+                        meta=collapsed_sample_meta,
+                    )
+                )
+                sequencing_to_add[external_sample_id].append(
+                    NewSequence(
+                        sample_id='<None>',  # keep the type initialisation happy
+                        meta=collapsed_sequencing_meta,
+                        type=SequenceType(sample_type),
+                        status=sequence_status,
+                    )
+                )
+
+        if not self.sample_metadata_project:
+            logger.info('No sample-metadata project set, so skipping add into SM-DB')
+            return samples_to_add, sequencing_to_add
+
+        logger.info(f'Adding {len(samples_to_add)} samples to SM-DB database')
+        ext_sample_to_internal_id = {}
+        for new_sample in samples_to_add:
+            sample_id = sapi.create_new_sample(
+                project=self.sample_metadata_project, new_sample=new_sample
+            )
+            ext_sample_to_internal_id[new_sample.external_id] = sample_id
+
+        for sample_id, sequences_to_add in sequencing_to_add.items():
+            for seq in sequences_to_add:
+                seq.sample_id = ext_sample_to_internal_id[sample_id]
+                seqapi.create_new_sequence(
+                    project=self.sample_metadata_project, new_sequence=seq
+                )
+
+        logger.info(f'Updating {len(samples_to_update)} samples')
+        for internal_sample_id, sample_update in samples_to_update.items():
+            sapi.update_sample(
+                project=self.sample_metadata_project,
+                id_=internal_sample_id,
+                sample_update_model=sample_update,
+            )
+
+        return ext_sample_to_internal_id
+
+    def parse_sequencing_type(self, sample_id: str, types: List[str]):
+        """
+        Parse sequencing type (wgs / single-cell, etc)
+        """
+        # filter false-y values
+        types = list(set(t for t in types if t))
+        if len(types) <= 0:
+            if (
+                self.default_sequencing_type is None
+                or self.default_sequencing_type.lower() == 'none'
+            ):
+                raise ValueError(
+                    f"Couldn't detect sequence type for sample {sample_id}, and "
+                    'no default was available.'
+                )
+            return self.default_sequencing_type
+        if len(types) > 1:
+            raise ValueError(
+                f'Multiple library types for same sample {sample_id}, '
+                f'maybe there are multiples types of sequencing in the same '
+                f'manifest? If so, please raise an issue with mfranklin to '
+                f'change the groupby to include {Columns.LIBRARY_STRATEGY}.'
+            )
+
+        type_ = types[0].lower()
+        if type_ == 'wgs':
+            return 'wgs'
+        if type_ in ('single-cell', 'ss'):
+            return 'single-cell'
+
+        raise ValueError(f'Unrecognised sequencing type {type_}')
+
+    def parse_reads(
+        self, reads: List[str]
+    ) -> Tuple[Union[List[List[Dict]], List[Dict]], str]:
+        """
+        Returns a tuple of:
+        1. single / list-of CWL file object(s), based on the extensions of the reads
+        2. parsed type (fastq, cram, bam)
+        """
+        if all(any(r.lower().endswith(ext) for ext in FASTQ_EXTENSIONS) for r in reads):
+            structured_fastqs = self.parse_fastqs_structure(reads)
+            files = []
+            for fastq_group in structured_fastqs:
+                files.append([self.create_file_object(f) for f in fastq_group])
+
+            return files, 'fastq'
+
+        if all(any(r.lower().endswith(ext) for ext in CRAM_EXTENSIONS) for r in reads):
+            sec_format = ['.crai', '^.crai']
+            files = []
+            for r in reads:
+                secondaries = self.create_secondary_file_objects_by_potential_pattern(
+                    r, sec_format
+                )
+                files.append(self.create_file_object(r, secondary_files=secondaries))
+
+            return files, 'cram'
+
+        if all(any(r.lower().endswith(ext) for ext in BAM_EXTENSIONS) for r in reads):
+            sec_format = ['.bai', '^.bai']
+            files = []
+            for r in reads:
+                secondaries = self.create_secondary_file_objects_by_potential_pattern(
+                    r, sec_format
+                )
+                files.append(self.create_file_object(r, secondary_files=secondaries))
+
+            return files, 'bam'
+
+        if all(any(r.lower().endswith(ext) for ext in VCFGZ_EXTENSIONS) for r in reads):
+            sec_format = ['.tbi']
+            files = []
+            for r in reads:
+                secondaries = self.create_secondary_file_objects_by_potential_pattern(
+                    r, sec_format
+                )
+                files.append(self.create_file_object(r, secondary_files=secondaries))
+
+            return files, 'bam'
+
+        extensions = set(os.path.splitext(r)[-1] for r in reads)
+        joined_reads = ''.join(f'\n\t{i}: {r}' for i, r in enumerate(reads))
+        raise ValueError(
+            f'Mixed, or unrecognised extensions ({", ".join(extensions)}) for reads: {joined_reads}'
+        )
+
+    @staticmethod
+    def parse_fastqs_structure(fastqs) -> List[List[str]]:
+        """
+        Takes a list of fastqs, and a set of nested lists of each R1 + R2 read.
+
+        >>> VcgsManifestParser.parse_fastqs_structure(['20210727_PROJECT1_L002_R2.fastq.gz', '20210727_PROJECT1_L002_R1.fastq.gz', '20210727_PROJECT1_L001_R2.fastq.gz', '20210727_PROJECT1_L001_R1.fastq.gz'])
+        [['20210727_PROJECT1_L002_R2.fastq.gz', '20210727_PROJECT1_L002_R1.fastq.gz'], ['20210727_PROJECT1_L001_R2.fastq.gz', '20210727_PROJECT1_L001_R1.fastq.gz']]
+
+
+        """
+        # find last instance of R\d, and then group by prefix on that
+        sorted_fastqs = sorted(fastqs)
+        r_matches = {r: rmatch.search(r) for r in sorted_fastqs}
+        no_r_match = [r for r, matched in r_matches.items() if matched is None]
+        if no_r_match:
+            no_r_match_str = ', '.join(no_r_match)
+            raise ValueError(
+                f"Couldn't detect the format of FASTQs (expected match for regex '{rmatch.pattern}'): {no_r_match_str}"
+            )
+
+        values = []
+        for _, grouped in groupby(sorted_fastqs, lambda r: r[: r_matches[r].start()]):
+            values.append(sorted(grouped))
+
+        return values
+
+    def create_file_object(
+        self,
+        filename,
+        secondary_files: List[Dict[str, any]] = None,
+    ) -> Dict[str, any]:
+        """Takes filename, returns formed CWL dictionary"""
+        checksum = None
+        md5_filename = filename + '.md5'
+        if self.file_exists(md5_filename):
+            checksum = f'md5:{self.file_contents(md5_filename).strip()}'
+
+        d = {
+            'location': self.file_path(filename),
+            'basename': os.path.basename(filename),
+            'class': 'File',
+            'checksum': checksum,
+            'size': self.file_size(filename),
+        }
+
+        if secondary_files:
+            d['secondaryFiles'] = secondary_files
+
+        return d
+
+    def create_secondary_file_objects_by_potential_pattern(
+        self, filename, potential_secondary_patterns: List[str]
+    ) -> List[Dict[str, any]]:
+        """
+        Take a base filename and potential secondary patterns:
+        - Try each secondary pattern, see if it works
+        - If it works, create a CWL file object
+        - return a list of those secondary file objects that exist
+        """
+        secondaries = []
+        for sec in potential_secondary_patterns:
+            sec_file = apply_secondary_file_format_to_filename(filename, sec)
+            if self.file_exists(sec_file):
+                secondaries.append(self.create_file_object(sec_file))
+
+        return secondaries
+
+
+def apply_secondary_file_format_to_filename(
+    filepath: Optional[str], secondary_file: str
+):
+    """
+    You can trust this function to do what you want
+    :param filepath: Filename to base
+    :param secondary_file: CWL secondary format (Remove 1 extension for each leading ^).
+    """
+    if not filepath:
+        return None
+
+    fixed_sec = secondary_file.lstrip('^')
+    leading = len(secondary_file) - len(fixed_sec)
+    if leading <= 0:
+        return filepath + fixed_sec
+
+    basepath = ''
+    filename = filepath
+    if '/' in filename:
+        idx = len(filepath) - filepath[::-1].index('/')
+        basepath = filepath[:idx]
+        filename = filepath[idx:]
+
+    split = filename.split('.')
+
+    newfname = filename + fixed_sec
+    if len(split) > 1:
+        newfname = '.'.join(split[: -min(leading, len(split) - 1)]) + fixed_sec
+    return basepath + newfname
+
+
+@click.command(help='GCS path to manifest file')
+@click.option(
+    '--project',
+    help='The CPG based project short-code, tagged as "sample.meta.project"',
+)
+@click.option(
+    '--sample-metadata-project',
+    help='The sample-metadata project to import manifest into (probably "seqr")',
+)
+@click.option('--default-sample-type', default='blood')
+@click.option('--default-sequence-type', default='wgs')
+@click.argument('manifests', nargs=-1)
+def main(
+    manifests,
+    project,
+    sample_metadata_project,
+    default_sample_type='blood',
+    default_sequence_type='wgs',
+):
+    """Run script from CLI arguments"""
+
+    for manifest in manifests:
+        logger.info(f'Importing {manifest}')
+        resp = VcgsManifestParser.from_manifest_path(
+            manifest=manifest,
+            project=project,
+            sample_metadata_project=sample_metadata_project,
+            default_sample_type=default_sample_type,
+            default_sequence_type=default_sequence_type,
+        )
+        print(resp)
+
+
+if __name__ == '__main__':
+    # pylint: disable=no-value-for-parameter
+    main()


### PR DESCRIPTION
- Genericise the importer, so can be easily subclassed, and a manifest can be imported.
- It's the subclasser's responsibility to form the sample and sequence meta fields, including the read objects
- The `Parser` base provides methods to help construct file objects, including with secondaries and interacting with GS.

FYI @vladsaveliev, @lgruen, @vivbak 