### PR TITLE
Add file map parser

### DIFF
--- a/scripts/parse_file_map.py
+++ b/scripts/parse_file_map.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # pylint: disable=too-many-instance-attributes,too-many-locals,unused-argument,no-self-use,wrong-import-order,unused-argument
 import logging
 import os

--- a/scripts/parse_file_map.py
+++ b/scripts/parse_file_map.py
@@ -48,7 +48,7 @@ class SampleMapParser(GenericParser):
 
     def populate_filename_map(self, search_locations: List[str]):
         """
-        ParseFileMap uses search locations based on the filename,
+        FileMapParser uses search locations based on the filename,
         so let's prepopulate that filename_map from the search_locations!
         """
         self.filename_map = {}
@@ -73,16 +73,16 @@ class SampleMapParser(GenericParser):
 
         return super().file_path(filename)
 
-    def get_sample_id(self, row: Dict[str, any]):
+    def get_sample_id(self, row: Dict[str, any]) -> str:
         """Get external sample ID from row"""
         external_id = row[Columns.INDIVIDUAL_ID]
         return external_id
 
-    def get_sample_meta(self, sample_id: str, row: GroupedRow):
+    def get_sample_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sample-metadata from row"""
         return {}
 
-    def get_sequence_meta(self, sample_id: str, row: GroupedRow):
+    def get_sequence_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sequence-metadata from row"""
         collapsed_sample_meta = {}
         if isinstance(row, list):
@@ -151,6 +151,11 @@ def main(
     """Run script from CLI arguments"""
     if not manifests:
         raise ValueError('Expected at least 1 manifest')
+
+    extra_seach_paths = [m for m in manifests if m.startswith('gs://')]
+    if extra_seach_paths:
+        search_path = list(set(search_path).union(set(extra_seach_paths)))
+
     for manifest in manifests:
         logger.info(f'Importing {manifest}')
         resp = SampleMapParser.from_manifest_path(

--- a/scripts/parse_file_map.py
+++ b/scripts/parse_file_map.py
@@ -1,0 +1,168 @@
+# pylint: disable=too-many-instance-attributes,too-many-locals,unused-argument,no-self-use,wrong-import-order,unused-argument
+import logging
+import os
+from io import StringIO
+from parser import GenericParser, GroupedRow
+from typing import Dict, List
+
+import click
+
+from sample_metadata.models.sequence_status import SequenceStatus
+
+logger = logging.getLogger(__file__)
+logger.addHandler(logging.StreamHandler())
+logger.setLevel(logging.INFO)
+
+
+class Columns:
+    """Column keys for file_map"""
+
+    INDIVIDUAL_ID = 'Individual ID'
+    FILENAMES = 'Filenames'
+
+
+class SampleMapParser(GenericParser):
+    """Parser for SampleMap"""
+
+    def __init__(
+        self,
+        search_locations: List[str],
+        sample_metadata_project: str,
+        default_sequence_type='wgs',
+        default_sample_type='blood',
+        confirm=False,
+        delimeter='\t',
+    ):
+        super().__init__(
+            path_prefix=search_locations[0],
+            sample_metadata_project=sample_metadata_project,
+            default_sequence_type=default_sequence_type,
+            default_sample_type=default_sample_type,
+            delimeter=delimeter,
+            confirm=confirm,
+        )
+        self.search_locations = search_locations
+        self.filename_map = {}
+        self.populate_filename_map(self.search_locations)
+
+    def populate_filename_map(self, search_locations: List[str]):
+        """
+        ParseFileMap uses search locations based on the filename,
+        so let's prepopulate that filename_map from the search_locations!
+        """
+        self.filename_map = {}
+        for directory in search_locations:
+            for file in self.list_directory(directory):
+                file_base = os.path.basename(file)
+                if file_base in self.filename_map:
+                    logger.warning(
+                        f'File "{file}" already exists in directory map: {self.filename_map[file_base]}'
+                    )
+                    continue
+                self.filename_map[file_base] = file
+
+    def file_path(self, filename: str) -> str:
+        """
+        Get complete filepath of filename:
+        - Includes gs://{bucket} if relevant
+        - Includes path_prefix decided early on
+        """
+        if filename in self.filename_map:
+            return self.filename_map[filename]
+
+        return super().file_path(filename)
+
+    def get_sample_id(self, row: Dict[str, any]):
+        """Get external sample ID from row"""
+        external_id = row[Columns.INDIVIDUAL_ID]
+        return external_id
+
+    def get_sample_meta(self, sample_id: str, row: GroupedRow):
+        """Get sample-metadata from row"""
+        return {}
+
+    def get_sequence_meta(self, sample_id: str, row: GroupedRow):
+        """Get sequence-metadata from row"""
+        collapsed_sample_meta = {}
+        if isinstance(row, list):
+            filenames = []
+            for r in row:
+                filenames.extend(r[Columns.FILENAMES].split(','))
+        else:
+            filenames = row[Columns.FILENAMES].split(',')
+        # strip in case collaborator put "file1, file2"
+        full_filenames = [self.file_path(f.strip()) for f in filenames]
+        reads, reads_type = self.parse_file(full_filenames)
+
+        collapsed_sample_meta['reads'] = reads
+        collapsed_sample_meta['reads_type'] = reads_type
+
+        return collapsed_sample_meta
+
+    def get_sequence_status(self, sample_id: str, row: GroupedRow) -> SequenceStatus:
+        """Get sequence status from row"""
+        return SequenceStatus('uploaded')
+
+    @staticmethod
+    def from_manifest_path(
+        manifest: str,
+        sample_metadata_project: str,
+        default_sequence_type='wgs',
+        default_sample_type='blood',
+        search_paths=None,
+        confirm=False,
+    ):
+        """Parse manifest from path, and return result of parsing manifest"""
+        parser = SampleMapParser(
+            search_locations=search_paths,
+            sample_metadata_project=sample_metadata_project,
+            default_sequence_type=default_sequence_type,
+            default_sample_type=default_sample_type,
+            confirm=confirm,
+        )
+
+        file_contents = parser.file_contents(manifest)
+        resp = parser.parse_manifest(StringIO(file_contents))
+
+        return resp
+
+
+@click.command(help='Parse manifest files')
+@click.option(
+    '--sample-metadata-project',
+    help='The sample-metadata project to import manifest into (probably "seqr")',
+)
+@click.option('--default-sample-type', default='blood')
+@click.option('--default-sequence-type', default='wgs')
+@click.option(
+    '--confirm', is_flag=True, help='Confirm with user input before updating server'
+)
+@click.option('--search-path', multiple=True, required=True)
+@click.argument('manifests', nargs=-1)
+def main(
+    manifests,
+    search_path: List[str],
+    sample_metadata_project,
+    default_sample_type='blood',
+    default_sequence_type='wgs',
+    confirm=False,
+):
+    """Run script from CLI arguments"""
+    if not manifests:
+        raise ValueError('Expected at least 1 manifest')
+    for manifest in manifests:
+        logger.info(f'Importing {manifest}')
+        resp = SampleMapParser.from_manifest_path(
+            manifest=manifest,
+            sample_metadata_project=sample_metadata_project,
+            default_sample_type=default_sample_type,
+            default_sequence_type=default_sequence_type,
+            confirm=confirm,
+            search_paths=search_path,
+        )
+        print(resp)
+
+
+if __name__ == '__main__':
+    # pylint: disable=no-value-for-parameter
+    main()

--- a/scripts/parse_vcgs_manifest.py
+++ b/scripts/parse_vcgs_manifest.py
@@ -7,9 +7,9 @@ from typing import Dict
 
 import click
 
-from sample_metadata.model.sample_type import SampleType
-from sample_metadata.model.sequence_status import SequenceStatus
-from sample_metadata.model.sequence_type import SequenceType
+from sample_metadata.models.sample_type import SampleType
+from sample_metadata.models.sequence_status import SequenceStatus
+from sample_metadata.models.sequence_type import SequenceType
 
 from parser import GenericParser, GroupedRow
 

--- a/scripts/parse_vcgs_manifest.py
+++ b/scripts/parse_vcgs_manifest.py
@@ -100,25 +100,28 @@ class VcgsManifestParser(GenericParser):
                 col: ','.join(set(r[col] for r in row))
                 for col in Columns.sample_columns()
             }
-            filenames = [self.file_path(r[Columns.FILENAME]) for r in row]
-            reads, reads_type = self.parse_file(filenames)
         else:
             collapsed_sample_meta = {col: row[col] for col in Columns.sample_columns()}
-            reads, reads_type = self.parse_file([self.file_path(row[Columns.FILENAME])])
-
-        collapsed_sample_meta['reads'] = reads
-        collapsed_sample_meta['reads_type'] = reads_type
 
         return collapsed_sample_meta
 
     def get_sequence_meta(self, sample_id: str, row: GroupedRow):
         """Get sequence-metadata from row"""
         if isinstance(row, list):
-            return {
+            sequence_meta = {
                 col: ','.join(set(r[col] for r in row))
                 for col in Columns.sequence_columns()
             }
-        return {col: row[col] for col in Columns.sequence_columns()}
+            filenames = [self.file_path(r[Columns.FILENAME]) for r in row]
+        else:
+            sequence_meta = {col: row[col] for col in Columns.sequence_columns()}
+            filenames = [self.file_path(row[Columns.FILENAME])]
+
+        reads, reads_type = self.parse_file(filenames)
+        sequence_meta['reads'] = reads
+        sequence_meta['reads_type'] = reads_type
+
+        return sequence_meta
 
     def get_sequence_type(self, sample_id: str, row: GroupedRow) -> SequenceType:
         """

--- a/scripts/parse_vcgs_manifest.py
+++ b/scripts/parse_vcgs_manifest.py
@@ -6,8 +6,6 @@ from io import StringIO
 from typing import Dict
 
 import click
-
-from sample_metadata.models.sample_type import SampleType
 from sample_metadata.models.sequence_status import SequenceStatus
 from sample_metadata.models.sequence_type import SequenceType
 
@@ -86,14 +84,14 @@ class VcgsManifestParser(GenericParser):
             confirm=confirm,
         )
 
-    def get_sample_id(self, row: Dict[str, any]):
+    def get_sample_id(self, row: Dict[str, any]) -> str:
         """Get external sample ID from row"""
         external_id = row[Columns.SAMPLE_NAME]
         if '-' in external_id:
             external_id = external_id.split('-')[0]
         return external_id
 
-    def get_sample_meta(self, sample_id: str, row: GroupedRow):
+    def get_sample_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sample-metadata from row"""
         if isinstance(row, list):
             collapsed_sample_meta = {
@@ -105,7 +103,7 @@ class VcgsManifestParser(GenericParser):
 
         return collapsed_sample_meta
 
-    def get_sequence_meta(self, sample_id: str, row: GroupedRow):
+    def get_sequence_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sequence-metadata from row"""
         if isinstance(row, list):
             sequence_meta = {
@@ -159,10 +157,6 @@ class VcgsManifestParser(GenericParser):
             return SequenceType('single-cell')
 
         raise ValueError(f'Unrecognised sequencing type {type_}')
-
-    def get_sample_type(self, sample_id: str, row: GroupedRow) -> SampleType:
-        """Get sample type from row"""
-        return self.default_sample_type
 
     def get_sequence_status(self, sample_id: str, row: GroupedRow) -> SequenceStatus:
         """Get sequence status from row"""

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -28,7 +28,7 @@ BAM_EXTENSIONS = ('.bam',)
 CRAM_EXTENSIONS = ('.cram',)
 VCFGZ_EXTENSIONS = ('.vcf.gz',)
 
-rmatch = re.compile(r'_[Rr]\d')
+rmatch = re.compile(r'[_\.-][Rr]\d')
 GroupedRow = Union[List[Dict[str, any]], Dict[str, any]]
 
 

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -109,6 +109,16 @@ class GenericParser:
         # first where r.name == path (or None)
         return next((r for r in blobs if r.name == path), None)
 
+    def list_directory(self, directory_name) -> List[str]:
+        """List directory"""
+        path = self.file_path(directory_name)
+        if path.startswith('gs://'):
+            bucket_name, *components = directory_name[5:].split('/')
+            blobs = self.client.list_blobs(bucket_name, prefix='/'.join(components))
+            return [f'gs://{bucket_name}/{blob.name}' for blob in blobs]
+
+        return [os.path.join(path, f) for f in os.listdir(path)]
+
     def file_contents(self, filename) -> Optional[str]:
         """Get contents of file (decoded as utf8)"""
         path = self.file_path(filename)

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -156,15 +156,15 @@ class GenericParser:
         return os.path.getsize(path)
 
     @abstractmethod
-    def get_sample_id(self, row: Dict[str, any]):
+    def get_sample_id(self, row: Dict[str, any]) -> str:
         """Get external sample ID from row"""
 
     @abstractmethod
-    def get_sample_meta(self, sample_id: str, row: GroupedRow):
+    def get_sample_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sample-metadata from row"""
 
     @abstractmethod
-    def get_sequence_meta(self, sample_id: str, row: GroupedRow):
+    def get_sequence_meta(self, sample_id: str, row: GroupedRow) -> Dict[str, any]:
         """Get sequence-metadata from row"""
 
     def get_sample_type(self, sample_id: str, row: GroupedRow) -> SampleType:

--- a/scripts/parser.py
+++ b/scripts/parser.py
@@ -1,4 +1,4 @@
-# pylint: disable=too-many-instance-attributes,too-many-locals
+# pylint: disable=too-many-instance-attributes,too-many-locals,unused-argument
 import csv
 import logging
 import os
@@ -51,8 +51,8 @@ class GenericParser:
 
         self.sample_metadata_project = sample_metadata_project
 
-        self.default_sequence_type = default_sequence_type
-        self.default_sample_type = default_sample_type
+        self.default_sequence_type: SequenceType = SequenceType(default_sequence_type)
+        self.default_sample_type: SampleType = SampleType(default_sample_type)
 
         # gs specific
         self.default_bucket = None
@@ -157,13 +157,13 @@ class GenericParser:
     def get_sequence_meta(self, sample_id: str, row: GroupedRow):
         """Get sequence-metadata from row"""
 
-    @abstractmethod
     def get_sample_type(self, sample_id: str, row: GroupedRow) -> SampleType:
         """Get sample type from row"""
+        return self.default_sample_type
 
-    @abstractmethod
     def get_sequence_type(self, sample_id: str, row: GroupedRow) -> SequenceType:
         """Get sequence type from row"""
+        return self.default_sequence_type
 
     @abstractmethod
     def get_sequence_status(self, sample_id: str, row: GroupedRow) -> SequenceStatus:


### PR DESCRIPTION
Notably, `reads` is going to `sequence.meta` (and I've updated the vcgs parser) - this is to better align with tob-wgs.

```tsv
Individual ID	Filenames
<sample-id>	<comma_R1.fastq.gz>,<separated_R1.fastq.gz>
```

Also supports:

```tsv
Individual ID	Filenames
<sample-id>	<sample_R1.fastq.gz>
<sample-id>	<sample_R2.fastq.gz>
```