### PR TITLE
Add generic md5 checker

### DIFF
--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -8,7 +8,8 @@ from google.cloud import storage
 
 def validate_all_objects_in_directory(gs_dir):
     """Validate files with MD5s in the provided gs directory"""
-    b = hb.Batch('validate_md5s')
+    backend = hb.ServiceBackend()
+    b = hb.Batch('validate_md5s', backend=backend)
     client = storage.Client()
 
     if not gs_dir.startswith('gs://'):

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -8,9 +8,12 @@ from google.cloud import storage
 DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:8cc869505251c8396fefef01c42225a7b7930a97-hail-0.2.73.devc6f6f09cec08'
 
 
-def validate_all_objects_in_directory(gs_dir, billing_project, bucket):
+def validate_all_objects_in_directory(gs_dir):
     """Validate files with MD5s in the provided gs directory"""
-    backend = hb.ServiceBackend(billing_project=billing_project, bucket=bucket)
+    backend = hb.ServiceBackend(
+        billing_project=os.getenv('HAIL_BILLING_PROJECT'),
+        bucket=os.getenv('HAIL_BUCKET'),
+    )
     b = hb.Batch('validate_md5s', backend=backend)
     client = storage.Client()
 
@@ -55,13 +58,9 @@ diff <(cat /tmp/uploaded.md5) <(gsutil cat {md5} | cut -d " " -f1)
 
 @click.command()
 @click.argument('gs_dir')
-@click.argument('billing_project')
-@click.argument('bucket')
-def main(gs_dir, billing_project, bucket):
+def main(gs_dir):
     """Main from CLI"""
-    validate_all_objects_in_directory(
-        gs_dir=gs_dir, billing_project=billing_project, bucket=bucket
-    )
+    validate_all_objects_in_directory(gs_dir=gs_dir)
 
 
 if __name__ == '__main__':

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from typing import Set
+
+import hailtop.batch as hb
+from google.cloud import storage
+
+
+def validate_all_objects_in_directory(gs_dir):
+    """Validate files with MD5s in the provided gs directory"""
+    b = hb.Batch('validate_md5s')
+    client = storage.Client()
+
+    if not gs_dir.startswith('gs://'):
+        raise ValueError(f'Expected GS directory, got: {gs_dir}')
+
+    bucket_name, *components = gs_dir[5:].split('/')
+
+    blobs = client.list_blobs(bucket_name, prefix='/'.join(components))
+    files: Set[str] = {f'gs://{bucket_name}/{blob.name}' for blob in blobs}
+    # TODO: remove this
+    dev_counter = 0
+    for obj in files:
+        if obj.endswith('.md5'):
+            continue
+        if f'{obj}.md5' not in files:
+            continue
+        if dev_counter >= 2:
+            break
+
+        dev_counter += 1
+        validate_md5(b.new_job(f'validate_{os.path.basename(obj)}'), obj)
+
+    b.run(wait=False)
+
+
+def validate_md5(job: hb.batch.job, file, md5_path=None) -> hb.batch.job:
+    """
+    This quickly validates a file and it's md5
+    """
+
+    # Calculate md5 checksum.
+    job.command(f'gsutil cat {file} | md5sum | cut -d " " -f1 > /tmp/uploaded.md5')
+
+    md5 = md5_path or f'{file}.md5'
+    job.command(f'diff <(cat /tmp/uploaded.md5) <(gsutil cat {md5} | cut -d " " -f1 )')
+
+    return job
+
+
+if __name__ == '__main__':
+    validate_all_objects_in_directory(sys.argv[1])

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -45,7 +45,7 @@ def validate_md5(job: hb.batch.job, file, md5_path=None) -> hb.batch.job:
     job.command(
         f"""\
 gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-gsutil cat {file} | md5sum | cut -d " " -f1 > /tmp/uploaded.md5)
+gsutil cat {file} | md5sum | cut -d " " -f1 > /tmp/uploaded.md5
 diff <(cat /tmp/uploaded.md5) <(gsutil cat {md5} | cut -d " " -f1)
     """
     )

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -6,9 +6,9 @@ import hailtop.batch as hb
 from google.cloud import storage
 
 
-def validate_all_objects_in_directory(gs_dir, billing_project):
+def validate_all_objects_in_directory(gs_dir, billing_project, bucket):
     """Validate files with MD5s in the provided gs directory"""
-    backend = hb.ServiceBackend(billing_project=billing_project)
+    backend = hb.ServiceBackend(billing_project=billing_project, bucket=bucket)
     b = hb.Batch('validate_md5s', backend=backend)
     client = storage.Client()
 
@@ -52,9 +52,12 @@ def validate_md5(job: hb.batch.job, file, md5_path=None) -> hb.batch.job:
 @click.command()
 @click.argument('gs_dir')
 @click.argument('billing_project')
-def main(gs_dir, billing_project):
+@click.argument('bucket')
+def main(gs_dir, billing_project, bucket):
     """Main from CLI"""
-    validate_all_objects_in_directory(gs_dir=gs_dir, billing_project=billing_project)
+    validate_all_objects_in_directory(
+        gs_dir=gs_dir, billing_project=billing_project, bucket=bucket
+    )
 
 
 if __name__ == '__main__':

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -5,6 +5,8 @@ import click
 import hailtop.batch as hb
 from google.cloud import storage
 
+DRIVER_IMAGE = 'australia-southeast1-docker.pkg.dev/analysis-runner/images/driver:8cc869505251c8396fefef01c42225a7b7930a97-hail-0.2.73.devc6f6f09cec08'
+
 
 def validate_all_objects_in_directory(gs_dir, billing_project, bucket):
     """Validate files with MD5s in the provided gs directory"""
@@ -30,7 +32,9 @@ def validate_all_objects_in_directory(gs_dir, billing_project, bucket):
             break
 
         dev_counter += 1
-        validate_md5(b.new_job(f'validate_{os.path.basename(obj)}'), obj)
+        job = b.new_job(f'validate_{os.path.basename(obj)}')
+        job.image(DRIVER_IMAGE)
+        validate_md5(job, obj)
 
     b.run(wait=False)
 

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -45,8 +45,8 @@ def validate_md5(job: hb.batch.job, file, md5_path=None) -> hb.batch.job:
     job.command(
         f"""\
 gcloud -q auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-gsutil cat {file} | md5sum | cut -d " " -f1 > /tmp/uploaded.md5')
-diff <(cat /tmp/uploaded.md5) <(gsutil cat {md5} | cut -d " " -f1 )
+gsutil cat {file} | md5sum | cut -d " " -f1 > /tmp/uploaded.md5)
+diff <(cat /tmp/uploaded.md5) <(gsutil cat {md5} | cut -d " " -f1)
     """
     )
 

--- a/scripts/check_md5s.py
+++ b/scripts/check_md5s.py
@@ -1,14 +1,14 @@
 import os
-import sys
 from typing import Set
 
+import click
 import hailtop.batch as hb
 from google.cloud import storage
 
 
-def validate_all_objects_in_directory(gs_dir):
+def validate_all_objects_in_directory(gs_dir, billing_project):
     """Validate files with MD5s in the provided gs directory"""
-    backend = hb.ServiceBackend()
+    backend = hb.ServiceBackend(billing_project=billing_project)
     b = hb.Batch('validate_md5s', backend=backend)
     client = storage.Client()
 
@@ -49,5 +49,14 @@ def validate_md5(job: hb.batch.job, file, md5_path=None) -> hb.batch.job:
     return job
 
 
+@click.command()
+@click.argument('gs_dir')
+@click.argument('billing_project')
+def main(gs_dir, billing_project):
+    """Main from CLI"""
+    validate_all_objects_in_directory(gs_dir=gs_dir, billing_project=billing_project)
+
+
 if __name__ == '__main__':
-    validate_all_objects_in_directory(sys.argv[1])
+    # pylint: disable=no-value-for-parameter
+    main()


### PR DESCRIPTION
For manual checking of md5 files in a directory.
Not very efficient, it'll load the list of files in the directory in memory and create a batch job for each pair of md5s.

Example: https://batch.hail.populationgenomics.org.au/batches/5026/jobs/1
