### PR TITLE
Improvements to analysis

### DIFF
--- a/api/routes/analysis.py
+++ b/api/routes/analysis.py
@@ -160,23 +160,29 @@ async def get_latest_complete_analysis_for_type_post(
     return analysis
 
 
-@router.get(
-    '/{project}/{analysis_type}/latest-complete',
-    operation_id='getLatestCompleteAnalysisForType',
+@router.post(
+    '/{project}/{analysis_type}/{latest-complete}/for-samples',
+    operation_id='getLatestAnalysisForSamplesAndType',
 )
-async def get_latest_complete_analysis_for_type(
+async def get_latest_analysis_for_samples_and_type(
+    sample_ids: List[str],
     analysis_type: AnalysisType,
+    allow_missing: bool = True,
     connection: Connection = get_project_readonly_connection,
 ):
-    """Get latest complete analysis for some analysis type"""
-    alayer = AnalysisLayer(connection)
-    analysis = await alayer.get_latest_complete_analysis_for_type(
-        project=connection.project, analysis_type=analysis_type
+    """Get latest complete gvcfs for sample"""
+    atable = AnalysisLayer(connection)
+    results = await atable.get_latest_complete_analysis_for_samples_and_type(
+        analysis_type=analysis_type,
+        sample_ids=sample_id_transform_to_raw(sample_ids),
+        allow_missing=allow_missing,
     )
-    if analysis:
-        analysis.sample_ids = sample_id_format(analysis.sample_ids)
 
-    return analysis
+    if results:
+        for result in results:
+            result.sample_ids = sample_id_format(result.sample_ids)
+
+    return results
 
 
 @router.get(

--- a/api/routes/analysis.py
+++ b/api/routes/analysis.py
@@ -46,7 +46,7 @@ class AnalysisUpdateModel(BaseModel):
     status: AnalysisStatus
     output: Optional[str] = None
     meta: Dict[str, Any] = None
-    active: bool = False
+    active: bool = None
 
 
 @router.put('/{project}/', operation_id='createNewAnalysis', response_model=int)

--- a/api/routes/analysis.py
+++ b/api/routes/analysis.py
@@ -164,7 +164,7 @@ async def get_latest_complete_analysis_for_type_post(
     '/{project}/{analysis_type}/latest-complete',
     operation_id='getLatestCompleteAnalysisForType',
 )
-async def get_latest_complete_analysis_for_type_meta(
+async def get_latest_complete_analysis_for_type(
     analysis_type: AnalysisType,
     connection: Connection = get_project_readonly_connection,
 ):

--- a/api/routes/analysis.py
+++ b/api/routes/analysis.py
@@ -161,7 +161,7 @@ async def get_latest_complete_analysis_for_type_post(
 
 
 @router.post(
-    '/{project}/{analysis_type}/{latest-complete}/for-samples',
+    '/{project}/{analysis_type}/latest-complete/for-samples',
     operation_id='getLatestAnalysisForSamplesAndType',
 )
 async def get_latest_analysis_for_samples_and_type(

--- a/db/project.xml
+++ b/db/project.xml
@@ -272,7 +272,7 @@
 			/>
 			<column
 				name="active"
-				type="bit"
+				type="BIT NOT NULL"
 				defaultValue="1"
 			/>
 			<column
@@ -280,6 +280,8 @@
 				type="VARCHAR(255)"
 			/>
 		</addColumn>
+		<sql>ALTER TABLE analysis MODIFY COLUMN status ENUM('queued', 'in-progress', 'failed', 'completed', 'unknown');</sql>
+
 	</changeSet>
 	<changeSet author="michael.franklin" id="2021-09-14_add-exome-sequence-type">
 		<sql>SET @@system_versioning_alter_history = 1;</sql>

--- a/db/project.xml
+++ b/db/project.xml
@@ -281,4 +281,8 @@
 			/>
 		</addColumn>
 	</changeSet>
+	<changeSet author="michael.franklin" id="2021-09-14_add-exome-sequence-type">
+		<sql>SET @@system_versioning_alter_history = 1;</sql>
+		<sql>ALTER TABLE sample_sequencing MODIFY COLUMN type ENUM('wgs', 'single-cell', 'exome');</sql>
+	</changeSet>
 </databaseChangeLog>

--- a/db/project.xml
+++ b/db/project.xml
@@ -261,4 +261,24 @@
 			/>
 		</addColumn>
 	</changeSet>
+	<changeSet author="michael.franklin" id="2021-09-13_add-analysis-improvements">
+		<sql>SET @@system_versioning_alter_history = 1;</sql>
+		<addColumn
+			tableName="analysis">
+			<column
+				name="meta"
+				type="JSON"
+				defaultValue="{}"
+			/>
+			<column
+				name="active"
+				type="bit"
+				defaultValue="1"
+			/>
+			<column
+				name="on_behalf_of"
+				type="VARCHAR(255)"
+			/>
+		</addColumn>
+	</changeSet>
 </databaseChangeLog>

--- a/db/python/layers/analysis.py
+++ b/db/python/layers/analysis.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from db.python.connect import Connection
 from db.python.layers.base import BaseLayer
@@ -32,11 +32,14 @@ class AnalysisLayer(BaseLayer):
         return analysis
 
     async def get_latest_complete_analysis_for_type(
-        self, project: ProjectId, analysis_type: AnalysisType
+        self,
+        project: ProjectId,
+        analysis_type: AnalysisType,
+        meta: Dict[str, any] = None,
     ) -> Analysis:
         """Get SINGLE latest complete analysis for some analysis type"""
         return await self.at.get_latest_complete_analysis_for_type(
-            project=project, analysis_type=analysis_type
+            project=project, analysis_type=analysis_type, meta=meta
         )
 
     async def get_latest_complete_analysis_for_samples_and_type(
@@ -100,7 +103,9 @@ class AnalysisLayer(BaseLayer):
         analysis_type: AnalysisType,
         status: AnalysisStatus,
         sample_ids: List[int],
+        meta: Dict[str, any],
         output: str = None,
+        active: bool = True,
         author: str = None,
         project: ProjectId = None,
     ) -> int:
@@ -109,7 +114,9 @@ class AnalysisLayer(BaseLayer):
             analysis_type=analysis_type,
             status=status,
             sample_ids=sample_ids,
+            meta=meta,
             output=output,
+            active=active,
             author=author,
             project=project,
         )
@@ -132,6 +139,7 @@ class AnalysisLayer(BaseLayer):
         self,
         analysis_id: int,
         status: AnalysisStatus,
+        meta: Dict[str, any] = None,
         output: Optional[str] = None,
         author: Optional[str] = None,
         check_project_id=True,
@@ -148,6 +156,7 @@ class AnalysisLayer(BaseLayer):
         await self.at.update_analysis(
             analysis_id=analysis_id,
             status=status,
+            meta=meta,
             output=output,
             author=author,
         )

--- a/db/python/tables/analysis.py
+++ b/db/python/tables/analysis.py
@@ -148,7 +148,8 @@ VALUES ({cs_id_keys}) RETURNING id;"""
         _query = f"""
 SELECT a.id as id, a.type as type, a.status as status,
         a.output as output, a_s.sample_id as sample_id,
-        a.project as project, a.timestamp_completed as timestamp_completed
+        a.project as project, a.timestamp_completed as timestamp_completed,
+        a.meta as meta
 FROM analysis_sample a_s
 INNER JOIN analysis a ON a_s.analysis_id = a.id
 WHERE a.id = (
@@ -160,7 +161,7 @@ WHERE a.id = (
 """
         rows = await self.connection.fetch_all(_query, values)
         if len(rows) == 0:
-            return NotFoundError(
+            raise NotFoundError(
                 f"Couldn't find any analysis with type {analysis_type.value}"
             )
         a = Analysis.from_db(**dict(rows[0]))
@@ -199,7 +200,7 @@ WHERE s.project = :project AND
         _query = f"""
 SELECT a.id as id, a.type as type, a.status as status,
         a.output as output, a_s.sample_id as sample_id,
-        a.project as project
+        a.project as project, a.meta as meta
 FROM analysis_sample a_s
 INNER JOIN analysis a ON a_s.analysis_id = a.id
 WHERE a.project = :project AND a.active AND (a.status='queued' OR a.status='in-progress')
@@ -223,7 +224,8 @@ WHERE a.project = :project AND a.active AND (a.status='queued' OR a.status='in-p
         """Get the latest complete analysis for samples (one per sample)"""
         _query = """
 SELECT a.id AS id, a.type as type, a.status as status, a.output as output,
-a.project as project, a_s.sample_id as sample_id, a.timestamp_completed as timestamp_completed
+a.project as project, a_s.sample_id as sample_id, a.timestamp_completed as timestamp_completed,
+a.meta as meta
 FROM analysis a
 LEFT JOIN analysis_sample a_s ON a_s.analysis_id = a.id
 WHERE

--- a/models/enums/analysis.py
+++ b/models/enums/analysis.py
@@ -18,3 +18,4 @@ class AnalysisStatus(Enum):
     IN_PROGRESS = 'in-progress'
     FAILED = 'failed'
     COMPLETED = 'completed'
+    UNKNOWN = 'unknown'

--- a/models/enums/sequencing.py
+++ b/models/enums/sequencing.py
@@ -5,6 +5,7 @@ class SequenceType(Enum):
     """Type of sequencing"""
 
     WGS = 'wgs'
+    EXOME = 'exome'
     SINGLE_CELL = 'single-cell'
 
 

--- a/models/models/analysis.py
+++ b/models/models/analysis.py
@@ -8,7 +8,7 @@ from models.enums import AnalysisType, AnalysisStatus
 class Analysis(SMBase):
     """Model for Analysis"""
 
-    id: str = None
+    id: int = None
     type: AnalysisType = None
     status: AnalysisStatus = None
     output: Optional[str] = None
@@ -26,7 +26,7 @@ class Analysis(SMBase):
         analysis_type = kwargs.pop('type', None)
         status = kwargs.pop('status', None)
         timestamp_completed = kwargs.pop('timestamp_completed', None)
-        meta = kwargs.pop('meta', None)
+        meta = kwargs.get('meta')
 
         if meta and isinstance(meta, str):
             meta = json.loads(meta)
@@ -42,7 +42,7 @@ class Analysis(SMBase):
             sample_ids=[kwargs.pop('sample_id')],
             output=kwargs.pop('output', []),
             timestamp_completed=timestamp_completed,
-            project=kwargs.pop('project'),
+            project=kwargs.get('project'),
             meta=meta,
-            active=kwargs.pop('active'),
+            active=kwargs.get('active'),
         )

--- a/models/models/analysis.py
+++ b/models/models/analysis.py
@@ -1,4 +1,5 @@
-from typing import Optional, List, Union
+from typing import Optional, List, Union, Dict, Any
+import json
 
 from models.base import SMBase
 from models.enums import AnalysisType, AnalysisStatus
@@ -14,6 +15,8 @@ class Analysis(SMBase):
     sample_ids: List[Union[str, int]] = None
     timestamp_completed: Optional[str] = None
     project: int = None
+    active: bool = None
+    meta: Dict[str, Any] = None
 
     @staticmethod
     def from_db(**kwargs):
@@ -22,9 +25,12 @@ class Analysis(SMBase):
         """
         analysis_type = kwargs.pop('type', None)
         status = kwargs.pop('status', None)
-        sample_ids = [kwargs.pop('sample_id')]
-        output = kwargs.pop('output', [])
         timestamp_completed = kwargs.pop('timestamp_completed', None)
+        meta = kwargs.pop('meta', None)
+
+        if meta and isinstance(meta, str):
+            meta = json.loads(meta)
+
         if timestamp_completed:
             if not isinstance(timestamp_completed, str):
                 timestamp_completed = timestamp_completed.isoformat()
@@ -33,8 +39,10 @@ class Analysis(SMBase):
             id=kwargs.pop('id'),
             type=AnalysisType(analysis_type),
             status=AnalysisStatus(status),
-            sample_ids=sample_ids,
-            output=output,
+            sample_ids=[kwargs.pop('sample_id')],
+            output=kwargs.pop('output', []),
             timestamp_completed=timestamp_completed,
             project=kwargs.pop('project'),
+            meta=meta,
+            active=kwargs.pop('active'),
         )


### PR DESCRIPTION
- Adds `meta`, `active` and `on_behalf_of` to analysis schema
    - `on_behalf_of` will be used in the future in the analysis runner to track the submitting user (vs the SM-authenticated request)
    - `active` is implemented as a follow-up to (#23) so hidden analysis can be created in test-projects - but is useful as a replacement to the airtable list of jobs run through the analysis-runner.
- Adds `unknown` to `AnalysisStatus`
- Adds `exome` to `SequenceType`

