### PR TITLE
Fix sample metadata parsers

### DIFF
--- a/sample_metadata/parser/generic_parser.py
+++ b/sample_metadata/parser/generic_parser.py
@@ -137,7 +137,7 @@ class GenericParser:  # pylint: disable=too-many-public-methods
         if path.startswith('gs://'):
             blob = self.get_blob(path)
             try:
-                retval = blob.download_as_string()
+                retval = blob.download_as_bytes()
                 if isinstance(retval, bytes):
                     retval = retval.decode()
                 return retval

--- a/scripts/arbitrary_sm.py
+++ b/scripts/arbitrary_sm.py
@@ -11,13 +11,16 @@ For example:
         --json '{"project": "acute-care", "external_id": "<external-id>"}'
 
 """
-import subprocess
 from typing import List
+import os.path
+import logging
+import subprocess
 
 import argparse
 import json
 
 from sample_metadata import apis
+from sample_metadata.model_utils import file_type
 
 
 def run_sm(
@@ -35,7 +38,29 @@ def run_sm(
     api_class_name = api_name.title() + 'Api'
     api = getattr(apis, api_class_name)
     api_instance = api()
+
+    # the latest sample-metadata API wants an IOBase, so let's
+    # scan through the params, open and substitute the files
+    openapi_types = getattr(api, f'{method_name}__endpoint').__dict__['openapi_types']
+    params_to_open = [
+        k
+        for k, t in openapi_types.items()
+        if any(isinstance(it, file_type) for it in t)
+    ]
+    files_to_close = []
+    modified_kwargs = {**kwargs}
+    for k in params_to_open:
+        potential_path = kwargs.get(k)
+        if potential_path and os.path.exists(potential_path):
+            files_to_close.append(open(potential_path))
+            modified_kwargs[k] = files_to_close[-1]
+        else:
+            logging.info(f'Skipping opening {k}')
+
     response = getattr(api_instance, method_name)(*(args or []), **(kwargs or {}))
+
+    for f in files_to_close:
+        f.close()
 
     return response
 

--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -44,7 +44,9 @@ logger.setLevel(logging.INFO)
     required=True,
     help='Search path to search for files within',
 )
-@click.option('--dry-run', is_flag=True, help='Just prepare the run, without comitting it')
+@click.option(
+    '--dry-run', is_flag=True, help='Just prepare the run, without comitting it'
+)
 @click.argument('manifests', nargs=-1)
 def main(
     manifests,

--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -44,6 +44,7 @@ logger.setLevel(logging.INFO)
     required=True,
     help='Search path to search for files within',
 )
+@click.option('--dry-run', is_flag=True, help='Just prepare the run, without comitting it')
 @click.argument('manifests', nargs=-1)
 def main(
     manifests,
@@ -52,6 +53,7 @@ def main(
     default_sample_type='blood',
     default_sequence_type='wgs',
     confirm=False,
+    dry_run=False,
 ):
     """Run script from CLI arguments"""
     if not manifests:
@@ -72,6 +74,7 @@ def main(
         resp = parser.from_manifest_path(
             manifest=manifest,
             confirm=confirm,
+            dry_run=dry_run,
         )
         print(resp)
 


### PR DESCRIPTION
- Change to `download_as_bytes` to fix https://issueexplorer.com/issue/googleapis/python-storage/510
- Add `dry-run` option to sample map parser for testing
- Allow `arbitrary_sm` to open files as `IOBase` to respect new generated sample-metadata structure