### PR TITLE
Adds project summary grid backend + typescript generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ web/build
 api/public
 web/src/static/sm_docs
 sm/
+web/src/sm-api/

--- a/README.md
+++ b/README.md
@@ -200,6 +200,26 @@ VSCode allows you to debug python modules, we could debug the web API at `api/se
 
 We could now place breakpoints on the sample route (ie: `api/routes/sample.py`), and debug requests as they come in.
 
+#### Developing the UI
+
+```shell
+# Ensure you have started sm locally on your computer already, then in another tab open the UI.
+# This will automatically proxy request to the server.
+cd web
+npm install
+npm start
+```
+
+
+#### Unauthenticated access
+
+You'll want to set the `SM_LOCALONLY_DEFAULTUSER` environment variable along with `ALLOWALLACCESS` to allow access to a local sample-metadata server without providing a bearer token. This will allow you to test the front-end components that access data. This happens automatically on the production instance through the Google identity-aware-proxy.
+
+```shell
+export SM_ALLOWALLACCESS=1
+export SM_LOCALONLY_DEFAULTUSER=$(whoami)
+```
+
 ### OpenAPI and Swagger
 
 The Web API uses `apispec` with OpenAPI3 annotations on each route to describe interactions with the server. We can generate a swagger UI and an installable

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -5,3 +5,4 @@ from api.routes.sequence import router as sequence_router
 from api.routes.participant import router as participant_router
 from api.routes.family import router as family_router
 from api.routes.project import router as project_router
+from api.routes.web import router as web_router

--- a/api/routes/project.py
+++ b/api/routes/project.py
@@ -9,11 +9,20 @@ from models.models.project import ProjectRow
 router = APIRouter(prefix='/project', tags=['project'])
 
 
-@router.get('/', operation_id='getProjects', response_model=List[ProjectRow])
-async def get_projects(connection=get_projectless_db_connection):
+@router.get('/all', operation_id='getAllProjects', response_model=List[ProjectRow])
+async def get_all_projects(connection=get_projectless_db_connection):
     """Get list of projects"""
     ptable = ProjectPermissionsTable(connection.connection)
     return await ptable.get_project_rows(author=connection.author)
+
+
+@router.get('/', operation_id='getMyProjects', response_model=List[str])
+async def get_my_projects(connection=get_projectless_db_connection):
+    """Get projects I have access to"""
+    ptable = ProjectPermissionsTable(connection.connection)
+    return await ptable.get_projects_accessible_by_user(
+        author=connection.author, readonly=True
+    )
 
 
 @router.put('/', operation_id='createProject')

--- a/api/routes/web.py
+++ b/api/routes/web.py
@@ -1,0 +1,95 @@
+"""
+Web routes
+"""
+from typing import Optional, List
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from models.models.sample import sample_id_format
+from db.python.layers.web import WebLayer, NestedParticipant
+
+from api.utils.db import (
+    get_project_readonly_connection,
+    Connection,
+)
+
+
+class PagingLinks(BaseModel):
+    """Model for PAGING"""
+
+    self: str
+    next: Optional[str]
+    token: Optional[str]
+
+
+class ProjectSummaryResponse(BaseModel):
+    """Response for the project summary"""
+
+    participants: List[NestedParticipant]
+    total_samples: int
+    sample_keys: List[str]
+    sequence_keys: List[str]
+
+    links: Optional[PagingLinks]
+
+    class Config:
+        """Config for ProjectSummaryResponse"""
+
+        fields = {'links': '_links'}
+
+
+router = APIRouter(prefix='/web', tags=['web'])
+
+
+@router.get(
+    '/{project}/summary',
+    response_model=ProjectSummaryResponse,
+    operation_id='getProjectSummary',
+)
+async def get_project_summary(
+    request: Request,
+    limit: int = 20,
+    token: Optional[str] = None,
+    connection: Connection = get_project_readonly_connection,
+) -> ProjectSummaryResponse:
+    """Creates a new sample, and returns the internal sample ID"""
+    st = WebLayer(connection)
+
+    summary = await st.get_project_summary(token=token, limit=limit)
+
+    if len(summary.participants) == 0:
+        return ProjectSummaryResponse(
+            participants=[],
+            sample_keys=[],
+            sequence_keys=[],
+            _links=None,
+            total_samples=0,
+        )
+
+    participants = summary.participants
+
+    collected_samples = sum(len(p.samples) for p in participants)
+    new_token = None
+    if collected_samples >= limit:
+        new_token = max(sample.id for p in participants for sample in p.samples)
+
+    for participant in participants:
+        for sample in participant.samples:
+            sample.id = sample_id_format(sample.id)
+
+    links = PagingLinks(
+        next=str(request.base_url) + request.url.path + f'?token={new_token}'
+        if new_token
+        else None,
+        self=str(request.url),
+        token=str(new_token) if new_token else None,
+    )
+
+    return ProjectSummaryResponse(
+        participants=participants,
+        total_samples=summary.total_samples,
+        sample_keys=summary.sample_keys,
+        sequence_keys=summary.sequence_keys,
+        _links=links,
+    )

--- a/api/server.py
+++ b/api/server.py
@@ -2,22 +2,16 @@ import os
 import time
 import traceback
 
-from fastapi import FastAPI, Request, HTTPException
+from fastapi import FastAPI, Request, HTTPException, APIRouter
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
 
 from db.python.connect import SMConnections
+from db.python.tables.project import ALLOW_FULL_ACCESS
 from db.python.utils import get_logger
 
-from api.routes import (
-    sample_router,
-    import_router,
-    analysis_router,
-    sequence_router,
-    participant_router,
-    family_router,
-    project_router,
-)
+from api import routes
 from api.utils import get_openapi_schema_func
 from api.utils.exceptions import determine_code_from_error
 
@@ -30,6 +24,15 @@ logger = get_logger()
 SKIP_DATABASE_CONNECTION = bool(os.getenv('SM_SKIP_DATABASE_CONNECTION'))
 app = FastAPI()
 
+if ALLOW_FULL_ACCESS:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=['*'],
+        allow_credentials=True,
+        allow_methods=['*'],
+        allow_headers=['*'],
+    )
+
 
 class SPAStaticFiles(StaticFiles):
     """
@@ -37,7 +40,10 @@ class SPAStaticFiles(StaticFiles):
     """
 
     async def get_response(self, path: str, scope):
-        """get response"""
+        """
+        Overide get response to server index.html if file isn't found
+        (to make single-page-app work correctly)
+        """
         response = await super().get_response(path, scope)
         if response.status_code == 404 and not path.startswith('api'):
             # server index.html if can't find existing resource
@@ -94,13 +100,10 @@ async def exception_handler(_: Request, e: Exception):
     )
 
 
-app.include_router(sample_router, prefix='/api/v1')
-app.include_router(import_router, prefix='/api/v1')
-app.include_router(analysis_router, prefix='/api/v1')
-app.include_router(sequence_router, prefix='/api/v1')
-app.include_router(participant_router, prefix='/api/v1')
-app.include_router(family_router, prefix='/api/v1')
-app.include_router(project_router, prefix='/api/v1')
+for route in routes.__dict__.values():
+    if not isinstance(route, APIRouter):
+        continue
+    app.include_router(route, prefix='/api/v1')
 
 static_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'public')
 if os.path.exists(static_dir):

--- a/api/utils/export.py
+++ b/api/utils/export.py
@@ -1,0 +1,26 @@
+from enum import Enum
+
+
+class ExportType(Enum):
+    """
+    Wraps up common properties and allows for parameterisation
+    of some table exports.
+    """
+
+    CSV = 'csv'
+    TSV = 'tsv'
+
+    def get_extension(self):
+        """Get extension (including .)"""
+        return {ExportType.CSV: '.csv', ExportType.TSV: '.tsv'}[self]
+
+    def get_delimiter(self):
+        """Get delimiter (eg: ',' OR '\t')"""
+        return {ExportType.CSV: ',', ExportType.TSV: '\t'}[self]
+
+    def get_mime_type(self):
+        """Get MIME type for response"""
+        return {
+            ExportType.CSV: 'text/csv',
+            ExportType.TSV: 'text/tab-separated-values',
+        }[self]

--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -210,6 +210,9 @@ class ParticipantLayer(BaseLayer):
             project=self.connection.project,
             allow_missing=True,
         )
+        if not unlinked_participants:
+            return '0 participants updated'
+
         external_participant_ids_to_add = set(
             external_sample_map_with_no_pid.keys()
         ) - set(unlinked_participants.keys())

--- a/db/python/layers/participant.py
+++ b/db/python/layers/participant.py
@@ -401,7 +401,7 @@ class ParticipantLayer(BaseLayer):
         """Get seqr individual level metadata template as List[List[str]]"""
 
         # avoid circular imports
-        # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel,cyclic-import
         from db.python.layers.family import FamilyLayer
 
         ppttable = ParticipantPhenotypeTable(self.connection)

--- a/db/python/layers/sample.py
+++ b/db/python/layers/sample.py
@@ -202,7 +202,7 @@ class SampleLayer(BaseLayer):
         if check_sample_ids:
             project_ids = set(r.project for r in rows)
             await self.ptable.check_access_to_project_ids(
-                self.author, project_ids, readonly=False
+                self.author, project_ids, readonly=True
             )
 
         return rows

--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -1,0 +1,289 @@
+# pylint: disable=too-many-locals
+import asyncio
+import dataclasses
+import json
+from collections import defaultdict
+from itertools import groupby
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+from db.python.connect import DbBase
+from db.python.layers.base import BaseLayer
+from models.enums import SampleType, SequenceType, SequenceStatus
+
+
+class NestedSequence(BaseModel):
+    """Sequence model"""
+
+    id: int
+    type: SequenceType
+    status: SequenceStatus
+    meta: Dict
+
+
+class NestedSample(BaseModel):
+    """Sample with nested sequences"""
+
+    id: str
+    external_id: str
+    type: SampleType
+    meta: Dict
+    sequences: List[NestedSequence]
+    created_date: Optional[str]
+
+
+class NestedFamily(BaseModel):
+    """Simplified family model"""
+
+    id: int
+    external_id: str
+
+
+class NestedParticipant(BaseModel):
+    """Participant with nested family and sampels"""
+
+    id: int
+    external_id: str
+    meta: Dict
+    families: List[NestedFamily]
+    samples: List[NestedSample]
+
+
+@dataclasses.dataclass
+class ProjectSummary:
+    """Return class for the project summary endpoint"""
+
+    total_samples: int
+    participants: List[NestedParticipant]
+    sample_keys: List[str]
+    sequence_keys: List[str]
+
+
+class WebLayer(BaseLayer):
+    """Web layer"""
+
+    async def get_project_summary(
+        self, token: Optional[str], limit: int = 50
+    ) -> ProjectSummary:
+        """
+        Get a summary of a project, allowing some "after" token,
+        and limit to the number of results.
+        """
+        webdb = WebDb(self.connection)
+        return await webdb.get_project_summary(token=token, limit=limit)
+
+
+class WebDb(DbBase):
+    """Db layer for web related routes,"""
+
+    def _project_summary_sample_query(self, after, limit):
+        """
+        Get query for getting list of samples
+        """
+        wheres = ['project = :project']
+        values = {'limit': limit, 'project': self.project}
+        if after:
+            values['after'] = after
+            wheres.append('id > :after')
+
+        where_str = ''
+        if wheres:
+            where_str = 'WHERE ' + ' AND '.join(wheres)
+        sample_query = f'SELECT id, external_id, type, meta, participant_id FROM sample {where_str} ORDER BY id LIMIT :limit'
+
+        return sample_query, values
+
+    @staticmethod
+    def _project_summary_process_sequence_rows_by_sample_id(
+        sequence_rows,
+    ) -> Dict[int, List[NestedSequence]]:
+        """
+        Get sequences for samples for project summary
+        """
+
+        seq_id_to_sample_id_map = {seq['id']: seq['sample_id'] for seq in sequence_rows}
+        seq_models = [
+            NestedSequence(
+                id=seq['id'],
+                status=SequenceStatus(seq['status']),
+                type=SequenceType(seq['type']),
+                meta=json.loads(seq['meta']),
+            )
+            for seq in sequence_rows
+        ]
+        seq_models_by_sample_id = {
+            k: list(v)
+            for k, v in (
+                groupby(seq_models, key=lambda s: seq_id_to_sample_id_map[s.id])
+            )
+        }
+
+        return seq_models_by_sample_id
+
+    @staticmethod
+    def _project_summary_process_sample_rows_by_pid(
+        sample_rows, seq_models_by_sample_id, sample_id_start_times: Dict[int, str]
+    ) -> Dict[int, List[NestedSample]]:
+        """
+        Process the returned sample rows into nested samples + sequences
+        """
+        sid_to_pid = {s['id']: s['participant_id'] for s in sample_rows}
+
+        smodels = [
+            NestedSample(
+                id=s['id'],
+                external_id=s['external_id'],
+                type=s['type'],
+                meta=json.loads(s['meta']),
+                created_date=sample_id_start_times.get(s['id'], ''),
+                sequences=seq_models_by_sample_id.get(s['id'], []),
+            )
+            for s in sample_rows
+        ]
+        # the pydantic model is casting to the id to a str, as that makes sense on the front end
+        # but cast back here to do the lookup
+        smodels_by_pid = {
+            k: list(v)
+            for k, v in (groupby(smodels, key=lambda s: sid_to_pid[int(s.id)]))
+        }
+
+        return smodels_by_pid
+
+    async def get_total_number_of_samples(self):
+        """Get total number of active samples within a project"""
+        _query = 'SELECT COUNT(*) FROM sample WHERE project = :project AND active'
+        return (await self.connection.fetch_one(_query, {'project': self.project}))[0]
+
+    @staticmethod
+    def _project_summary_process_family_rows_by_pid(
+        family_rows,
+    ) -> Dict[int, List[NestedFamily]]:
+        """
+        Process the family rows into NestedFamily objects
+        """
+        pid_to_fids = defaultdict(list)
+        for frow in family_rows:
+            pid_to_fids[frow['participant_id']].append(frow['family_id'])
+
+        res_families = {}
+        for f in family_rows:
+            if f['family_id'] in family_rows:
+                continue
+            res_families[f['family_id']] = NestedFamily(
+                id=f['family_id'], external_id=f['external_family_id']
+            )
+        pid_to_families = {
+            pid: [res_families[fid] for fid in fids]
+            for pid, fids in pid_to_fids.items()
+        }
+        return pid_to_families
+
+    async def _project_summary_get_sample_create_date(self, sample_ids: List[int]):
+        """Get a map of {internal_sample_id: date_created} for list of sample_ids"""
+        _query = 'SELECT id, min(row_start) FROM sample FOR SYSTEM_TIME ALL WHERE id in :sids GROUP BY id'
+        rows = await self.connection.fetch_all(_query, {'sids': sample_ids})
+        return {r[0]: str(r[1].date()) for r in rows}
+
+    async def get_project_summary(
+        self, token: Optional[str], limit: int
+    ) -> ProjectSummary:
+        """
+        Get project summary
+
+        :param token: for PAGING
+        :param limit: Number of SAMPLEs to return, not including nested sequences
+        """
+        # do initial query to get sample info
+        sample_query, values = self._project_summary_sample_query(token, limit)
+        sample_rows = list(await self.connection.fetch_all(sample_query, values))
+
+        if len(sample_rows) == 0:
+            return ProjectSummary(
+                participants=[], sample_keys=[], sequence_keys=[], total_samples=0
+            )
+
+        pids = list(set(s['participant_id'] for s in sample_rows))
+        sids = list(s['id'] for s in sample_rows)
+
+        # sequences
+
+        seq_query = 'SELECT id, sample_id, meta, type, status FROM sample_sequencing WHERE sample_id IN :sids'
+        sequence_promise = self.connection.fetch_all(seq_query, {'sids': sids})
+
+        # participant
+        p_query = 'SELECT id, external_id, meta FROM participant WHERE id in :pids'
+        participant_promise = self.connection.fetch_all(p_query, {'pids': pids})
+
+        # family
+        f_query = """
+SELECT f.id as family_id, f.external_id as external_family_id, fp.participant_id
+FROM family_participant fp
+INNER JOIN family f ON f.id = fp.family_id
+WHERE fp.participant_id in :pids
+        """
+        family_promise = self.connection.fetch_all(f_query, {'pids': pids})
+
+        [
+            sequence_rows,
+            participant_rows,
+            family_rows,
+            sample_id_start_times,
+            total_samples,
+        ] = await asyncio.gather(
+            sequence_promise,
+            participant_promise,
+            family_promise,
+            self._project_summary_get_sample_create_date(sids),
+            self.get_total_number_of_samples(),
+        )
+
+        # post-processing
+        seq_models_by_sample_id = (
+            self._project_summary_process_sequence_rows_by_sample_id(sequence_rows)
+        )
+        smodels_by_pid = self._project_summary_process_sample_rows_by_pid(
+            sample_rows, seq_models_by_sample_id, sample_id_start_times
+        )
+        pid_to_families = self._project_summary_process_family_rows_by_pid(family_rows)
+
+        pmodels = [
+            NestedParticipant(
+                id=p['id'],
+                external_id=p['external_id'],
+                meta=json.loads(p['meta']),
+                families=pid_to_families.get(p['id'], []),
+                samples=list(smodels_by_pid.get(p['id'])),
+            )
+            for p in participant_rows
+        ]
+
+        ignore_sample_meta_keys = {'reads', 'vcfs'}
+        ignore_sequence_meta_keys = {'reads', 'vcfs'}
+        sample_meta_keys = set(
+            sk
+            for p in pmodels
+            for s in p.samples
+            for sk in s.meta.keys()
+            if (sk not in ignore_sample_meta_keys)
+        )
+        sequence_meta_keys = set(
+            sk
+            for p in pmodels
+            for s in p.samples
+            for seq in s.sequences
+            for sk in seq.meta
+            if (sk not in ignore_sequence_meta_keys)
+        )
+
+        sample_keys = ['id', 'external_id', 'created_date'] + [
+            'meta.' + k for k in sample_meta_keys
+        ]
+        sequence_keys = ['type'] + ['meta.' + k for k in sequence_meta_keys]
+
+        return ProjectSummary(
+            participants=pmodels,
+            sample_keys=sample_keys,
+            sequence_keys=sequence_keys,
+            total_samples=total_samples,
+        )

--- a/db/python/tables/participant.py
+++ b/db/python/tables/participant.py
@@ -138,6 +138,9 @@ RETURNING id
         """Get map of {external_id: internal_participant_id}"""
         assert project
 
+        if len(external_participant_ids) == 0:
+            return {}
+
         _query = 'SELECT external_id, id FROM participant WHERE external_id in :external_ids AND project = :project'
         results = await self.connection.fetch_all(
             _query,

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Dict, List, Set, Iterable, Optional, Tuple
 
 import os
@@ -266,6 +267,28 @@ class ProjectPermissionsTable:
         _query = 'SELECT id, name, gcp_id, dataset, read_secret_name, write_secret_name FROM project'
         rows = await self.connection.fetch_all(_query)
         return list(map(ProjectRow.from_db, rows))
+
+    async def get_projects_accessible_by_user(self, author: str, readonly=True):
+        """
+        Get projects that are accessible by the specified user
+        """
+        assert author
+
+        _query = 'SELECT id, name FROM project'
+        project_id_map = {p[0]: p[1] for p in await self.connection.fetch_all(_query)}
+
+        promises = [
+            self.check_access_to_project_id(author, pid, readonly=readonly)
+            for pid in project_id_map.keys()
+        ]
+        has_access_to_project = await asyncio.gather(*promises)
+        relevant_project_names = [
+            name
+            for name, has_access in zip(project_id_map.values(), has_access_to_project)
+            if has_access
+        ]
+
+        return relevant_project_names
 
     async def create_project(
         self,

--- a/regenerate_api.py
+++ b/regenerate_api.py
@@ -158,9 +158,7 @@ def copy_typescript_files_from(tmpdir):
     dir_to_copy_from = tmpdir
 
     if not os.path.exists(dir_to_copy_to):
-        raise FileNotFoundError(
-            f"Directory to copy to doesn't exist ({dir_to_copy_to})"
-        )
+        os.makedirs(dir_to_copy_to)
     if not os.path.exists(dir_to_copy_from):
         raise FileNotFoundError(
             f"Directory to copy from doesn't exist ({dir_to_copy_from})"


### PR DESCRIPTION
Partial changes from #117.

**Adds a project summary table that allows you to select a project, and displays a paged list of samples in a table.**

Technical:

- Adds automatic typescript binding generation from openapi
- Adds local development option for default authorisation (without bearer token, useful for development of front-end)
- Adds PAGED web route for getting a project summary