### PR TITLE
Ensure typescript API is using correct URL

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,8 +42,8 @@ jobs:
 
       - uses: actions/setup-java@v2
         with:
-          distribution: 'temurin' # See 'Supported distributions' for available options
-          java-version: '17'
+          distribution: "temurin" # See 'Supported distributions' for available options
+          java-version: "17"
 
       - name: Setup build env
         run: |
@@ -54,8 +54,10 @@ jobs:
         run: |
           if [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             echo DEPLOYMENT_TYPE=prod >> $GITHUB_ENV
+            echo SM_ENVIRONMENT=production >> $GITHUB_ENV
           else
             echo DEPLOYMENT_TYPE=dev >> $GITHUB_ENV
+            echo SM_ENVIRONMENT=development >> $GITHUB_ENV
             pip install bump2version
             # add
             bump2version patch \
@@ -66,7 +68,11 @@ jobs:
       # generate the openapi file to then generate the documentation
       - name: "build image"
         run: |
-          docker build --tag $SM_DOCKER -f deploy/api/Dockerfile .
+          docker build \
+            --build-arg SM_ENVIRONMENT=$SM_ENVIRONMENT \
+            --tag $SM_DOCKER \
+            -f deploy/api/Dockerfile \
+            .
 
       - name: "build deployable API"
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   build-publish:
     # Run on merge to main, where the commit name starts with "Bump version:" (for bump2version)
-#    if: "startsWith(github.event.head_commit.message, 'Bump version:')"
+    #    if: "startsWith(github.event.head_commit.message, 'Bump version:')"
     runs-on: ubuntu-latest
     env:
       DOCKER_BUILDKIT: 1
@@ -33,7 +33,7 @@ jobs:
 
       - name: "build image"
         run: |
-          docker build --tag $SM_DOCKER -f deploy/api/Dockerfile .
+          docker build --build-arg SM_ENVIRONMENT=local --tag $SM_DOCKER -f deploy/api/Dockerfile .
 
       - name: "build deployable API"
         run: |

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Or you can build the docker file, and specify that
 ```bash
 # SM_DOCKER is a known env variable to regenerate_api.py
 export SM_DOCKER="cpg/sample-metadata-server:dev"
-docker build -t $SM_DOCKER -f deploy/api/Dockerfile .
+docker build --build-arg SM_ENVIRONMENT=local -t $SM_DOCKER -f deploy/api/Dockerfile .
 python regenerate_apy.py
 ```
 

--- a/deploy/api/Dockerfile
+++ b/deploy/api/Dockerfile
@@ -1,9 +1,11 @@
 FROM debian:buster-slim
 
+ARG SM_ENVIRONMENT
+
 ENV MAMBA_ROOT_PREFIX /root/micromamba
 ENV PATH $MAMBA_ROOT_PREFIX/bin:$PATH
 ENV PORT 8000
-ENV SM_ENVIRONMENT "development"
+ENV SM_ENVIRONMENT ${SM_ENVIRONMENT}
 # Allow statements and log messages to immediately appear in the Knative logs.
 ENV PYTHONUNBUFFERED 1
 


### PR DESCRIPTION
The new API isn't working on sample-metadata.populationgenomics because the URL returned by openapi in the generation during deploy was defaulting to the "dev" environment.

Unfortunately the typescript-axios environment requires a fixed URL (relative base path doesn't work), so as a work-around I've made the deploy stage pass an SM_ENVIRONMENT url, so the server will return the "correct" base path for the environment we're building for. 