### PR TITLE
Fix non ordinary display values in grid

### DIFF
--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -258,8 +258,8 @@ WHERE fp.participant_id in :pids
             for p in participant_rows
         ]
 
-        ignore_sample_meta_keys = {'reads', 'vcfs'}
-        ignore_sequence_meta_keys = {'reads', 'vcfs'}
+        ignore_sample_meta_keys = {'reads', 'vcfs', 'gvcf'}
+        ignore_sequence_meta_keys = {'reads', 'vcfs', 'gvcf'}
         sample_meta_keys = set(
             sk
             for p in pmodels

--- a/web/src/project/ProjectSummary.tsx
+++ b/web/src/project/ProjectSummary.tsx
@@ -12,6 +12,14 @@ import { Input, Button } from 'reactstrap'
 
 const PAGE_SIZES = [20, 40, 100, 1000]
 
+const sanitiseValue = (value: any) => {
+    const tvalue = typeof value
+    if (tvalue === 'string' || tvalue === 'number') return value
+    if (tvalue === 'boolean') return value ? 'true' : 'false'
+    if (value === undefined || value === null) return ''
+    return JSON.stringify(value)
+}
+
 
 export const ProjectSummary = () => {
 
@@ -145,8 +153,8 @@ export const ProjectSummary = () => {
                             return <tr key={`${p.external_id}-${s.id}-${seq.id}`}>
                                 {sidx === 0 && seqidx === 0 && <td style={{ backgroundColor }} rowSpan={lengthOfParticipant}>{p.families.map(f => f.external_id).join(', ')}</td>}
                                 {sidx === 0 && seqidx === 0 && <td style={{ backgroundColor }} rowSpan={lengthOfParticipant}>{p.external_id}</td>}
-                                {seqidx === 0 && summary.sample_keys.map(k => <td style={{ backgroundColor }} key={s.id + 'sample.' + k} rowSpan={s.sequences.length}>{_.get(s, k)}</td>)}
-                                {seq && summary.sequence_keys.map(k => <td style={{ backgroundColor }} key={s.id + 'sequence.' + k}>{_.get(seq, k)}</td>)}
+                                {seqidx === 0 && summary.sample_keys.map(k => <td style={{ backgroundColor }} key={s.id + 'sample.' + k} rowSpan={s.sequences.length}>{sanitiseValue(_.get(s, k))}</td>)}
+                                {seq && summary.sequence_keys.map(k => <td style={{ backgroundColor }} key={s.id + 'sequence.' + k}>{sanitiseValue(_.get(seq, k))}</td>)}
                             </tr>
                         })
 


### PR DESCRIPTION
In the project summary grid, I try to block out anything with large nested values (like the reads block), but I missed the `gvcf` for tob-wgs. React doesn't like json objects displayed directly (this currently crashes the the react app and there's no error boundary 😞). 

This PR adds a `sanitiseValue` function that simply checks the type, and if it's not a supported type then it `json.stringify`-ies anything it doesn't recognise to avoid these crashes.