### PR TITLE
Fix getMyProjects call

### DIFF
--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -278,7 +278,7 @@ class ProjectPermissionsTable:
         project_id_map = {p[0]: p[1] for p in await self.connection.fetch_all(_query)}
 
         promises = [
-            self.check_access_to_project_id(author, pid, readonly=readonly)
+            self.check_access_to_project_id(author, pid, readonly=readonly, raise_exception=False)
             for pid in project_id_map.keys()
         ]
         has_access_to_project = await asyncio.gather(*promises)

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -278,7 +278,9 @@ class ProjectPermissionsTable:
         project_id_map = {p[0]: p[1] for p in await self.connection.fetch_all(_query)}
 
         promises = [
-            self.check_access_to_project_id(author, pid, readonly=readonly, raise_exception=False)
+            self.check_access_to_project_id(
+                author, pid, readonly=readonly, raise_exception=False
+            )
             for pid in project_id_map.keys()
         ]
         has_access_to_project = await asyncio.gather(*promises)


### PR DESCRIPTION
Stop check_access_to_project_id from raising exceptions during getMyProjects call.