### PR TITLE
Refactor secrets out of SM

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ There are three components to the sample-metadata system:
 - An installable python library that wraps the Python web API (using OpenAPI generator)
 
 Every resource in sample-metadata belongs to a project. All resources are access
-controlled through membership of the google groups:
-`$dataset-sample-metadata-main-{read,write}`. Note that members of google-groups
-are cached in a secret as group-membership identity checks are slow.
+controlled through membership of specified google groups. Note that members of google-groups
+are cached in a group as group-membership identity checks are slow.
 
 
 ## Structure
@@ -272,24 +271,4 @@ Or you can build the docker file, and specify that
 export SM_DOCKER="cpg/sample-metadata-server:dev"
 docker build --build-arg SM_ENVIRONMENT=local -t $SM_DOCKER -f deploy/api/Dockerfile .
 python regenerate_apy.py
-```
-
-
-
-## Deployment
-
-The sample-metadata server
-
-You'll want to complete the following steps:
-
-- Ensure there is a database created for each project (with the database name being the project),
-- Ensure there are secrets in `projects/sample_metadata/secrets/databases/versions/latest`, that's an array of objects with keys `dbname, host, port, username, password`.
-- Ensure `google-cloud` was installed
-
-```bash
-export SM_ENVIRONMENT='PRODUCTION'
-
-# OR, point to the dev instance with
-export SM_ENVIRONMENT='DEVELOPMENT'
-
 ```

--- a/db/project.xml
+++ b/db/project.xml
@@ -334,4 +334,17 @@
 		</sql>
 
 	</changeSet>
+	<changeSet author="michael.franklin" id="2022-04-19_secrets-to-groups">
+
+		<renameColumn
+            newColumnName="read_secret_name"
+            oldColumnName="read_group_name"
+            tableName="project"
+		/>
+		<renameColumn
+			newColumnName="write_secret_name"
+            oldColumnName="write_group_name"
+            tableName="project"
+		/>
+	</changeSet>
 </databaseChangeLog>

--- a/models/models/project.py
+++ b/models/models/project.py
@@ -9,8 +9,8 @@ class ProjectRow(SMBase):
     name: Optional[str] = None
     gcp_id: Optional[str] = None
     dataset: Optional[str] = None
-    read_secret_name: Optional[str] = None
-    write_secret_name: Optional[str] = None
+    read_group_name: Optional[str] = None
+    write_group_name: Optional[str] = None
 
     @staticmethod
     def from_db(kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 cpg-utils
 requests==2.25.1
 google-auth==1.35.0
-google-cloud-secret-manager==2.8.0
 google-cloud-logging==2.7.0
 google-cloud-storage==1.43.0
 fastapi[all]==0.70.0


### PR DESCRIPTION
- Use new group-cache methods in cpg-utils (relies on https://github.com/populationgenomics/cpg-utils/pull/29)
- Allow project-creator-group to be specified through environment variables:

DEPLOY ACTION:
- Create environment variable in deploy for project-creator group