### PR TITLE
Fix failed backups 

### DIFF
--- a/db/backup/backup.py
+++ b/db/backup/backup.py
@@ -23,8 +23,13 @@ def perform_backup():
     utc_now = pytz.utc.localize(datetime.utcnow())
     timestamp_str = utc_now.strftime('%d_%m_%Y_%H-%M-%S')
 
-    # Export SQL Data
+    # Set up tmp dir
     tmp_dir = f'backup_{timestamp_str}'
+    subprocess.run(['mkdir', tmp_dir], check=True)
+    # grant permissions, so that mariadb can read ib_logfile0
+    subprocess.run(['sudo', 'chmod', '-R', '777', tmp_dir], check=True)
+
+    # Export SQL Data
     try:
         subprocess.run(
             [


### PR DESCRIPTION
Backups were failing with the error `error: failed to open the target stream for 'ib_logfile0'.`
This error was encountered previously and was handled by modifying permissions on the machine that runs `backup.py` i.e.
`sudo chmod g+r /var/lib/mysql/ibdata1`

However, the location of the `ib_logfile0`, has moved from `/var/lib/mysql/ibdata1`. Instead mariabackup outputs the file to the `targetdir` specified in the `mariabackup` call. 

In this PR, permissions to the `targetdir` are modified directly before `mariabackup` is run. 