### PR TITLE
Fix sample grid for missing participants

### DIFF
--- a/db/python/layers/web.py
+++ b/db/python/layers/web.py
@@ -300,7 +300,7 @@ WHERE fp.participant_id in :pids
         participant_meta_keys = set(
             pk
             for p in pmodels
-            if p
+            if p and p.meta
             for pk in p.meta.keys()
             if pk not in ignore_participant_keys
         )


### PR DESCRIPTION
Failing because participant doesn't exist - meta doesn't exist which means the participant keys don't get filled - and except out.