### PR TITLE
Parser fixes

### DIFF
--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -99,7 +99,7 @@ class CloudHelper:
     async def file_size(self, filename) -> int:
         """Get size of file in bytes"""
         return AnyPath(self.file_path(filename)).stat().st_size
-    
+
     def populate_filename_map(
         self, search_locations: list[str]
     ) -> dict[str, str]:
@@ -116,8 +116,7 @@ class CloudHelper:
                 file_base = os.path.basename(file)
                 if file_base in fn_map:
                     logging.warning(
-                        f'File "{file}" from "{directory}" already exists in '
-                        f'directory map: {fn_map[file_base]}'
+                        f'File "{file}" from "{directory}" already exists in directory map: {fn_map[file_base]}'
                     )
                     continue
                 fn_map[file_base] = file

--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -108,7 +108,7 @@ class CloudHelper:
         so let's prepopulate that filename_map from the search_locations!
         """
 
-        fn_map = {}
+        fn_map: dict[str, str] = {}
         for directory in search_locations:
             directory_list = self.list_directory(directory)
             for file in directory_list:

--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -2,7 +2,7 @@
 import os
 import logging
 
-from cloudpathlib import AnyPath
+from cloudpathlib import AnyPath, GSPath
 from google.cloud import storage
 
 
@@ -19,7 +19,8 @@ class CloudHelper:
 
         self.search_paths = search_paths or []
 
-        self.filename_map: dict[str, str] = self.populate_filename_map(self.search_paths)
+        self.filename_map: dict[str, str] = {}
+        self.populate_filename_map(self.search_paths)
         # pylint: disable
 
     @staticmethod
@@ -108,20 +109,20 @@ class CloudHelper:
         so let's prepopulate that filename_map from the search_locations!
         """
 
-        fn_map = {}
         for directory in search_locations:
             directory_list = self.list_directory(directory)
             for file in directory_list:
                 file = file.strip()
                 file_base = os.path.basename(file)
-                if file_base in fn_map:
+                if file_base in self.filename_map:
                     logging.warning(
-                        f'File "{file}" from "{directory}" already exists in directory map: {self.filename_map[file_base]}'
+                        f'File "{file}" from "{directory}" already exists in '
+                        f'directory map: {self.filename_map[file_base]}'
                     )
                     continue
-                fn_map[file_base] = file
+                self.filename_map[file_base] = file
 
-        return fn_map
+        return self.filename_map
 
     # GCS specific methods
     @property
@@ -155,7 +156,12 @@ class CloudHelper:
 
     def _list_gcs_directory(self, gcs_path) -> list[str]:
 
-        bucket_name, remaining_path = gcs_path[5:].split('/', maxsplit=1)
-        bucket = self.get_gcs_bucket(bucket_name)
-        blobs = self.gcs_client.list_blobs(bucket, prefix=remaining_path, delimiter='/')
-        return [f'gs://{bucket_name}/{blob.name}' for blob in blobs]
+        path = GSPath(gcs_path)
+        if path.parts[2:]:
+            remaining_path = '/'.join(path.parts[2:]) + '/'  # has to end with "/"
+        else:
+            remaining_path = None
+        blobs = self.gcs_client.list_blobs(
+            path.bucket, prefix=remaining_path, delimiter='/'
+        )
+        return [f'gs://{path.bucket}/{blob.name}' for blob in blobs]

--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -19,8 +19,7 @@ class CloudHelper:
 
         self.search_paths = search_paths or []
 
-        self.filename_map: dict[str, str] = {}
-        self.populate_filename_map(self.search_paths)
+        self.filename_map: dict[str, str] = self.populate_filename_map(self.search_paths)
         # pylint: disable
 
     @staticmethod
@@ -100,7 +99,7 @@ class CloudHelper:
     async def file_size(self, filename) -> int:
         """Get size of file in bytes"""
         return AnyPath(self.file_path(filename)).stat().st_size
-
+    
     def populate_filename_map(
         self, search_locations: list[str]
     ) -> dict[str, str]:
@@ -109,20 +108,21 @@ class CloudHelper:
         so let's prepopulate that filename_map from the search_locations!
         """
 
+        fn_map = {}
         for directory in search_locations:
             directory_list = self.list_directory(directory)
             for file in directory_list:
                 file = file.strip()
                 file_base = os.path.basename(file)
-                if file_base in self.filename_map:
+                if file_base in fn_map:
                     logging.warning(
                         f'File "{file}" from "{directory}" already exists in '
-                        f'directory map: {self.filename_map[file_base]}'
+                        f'directory map: {fn_map[file_base]}'
                     )
                     continue
-                self.filename_map[file_base] = file
+                fn_map[file_base] = file
 
-        return self.filename_map
+        return fn_map
 
     # GCS specific methods
     @property

--- a/sample_metadata/parser/generic_metadata_parser.py
+++ b/sample_metadata/parser/generic_metadata_parser.py
@@ -303,7 +303,7 @@ class GenericMetadataParser(GenericParser):
 
         filenames: List[str] = sum(await asyncio.gather(*filename_promises), [])
         fs = set(f.strip() for f in filenames if f and f.strip())
-        relevant_extensions = ('.cram', '.crai', '.fq.gz', '.fastq.gz', '.bam', '.bai')
+        relevant_extensions = ('.cram', '.fastq.gz', '.bam')
 
         def filename_filter(f):
             return any(f.endswith(ext) for ext in relevant_extensions)

--- a/sample_metadata/parser/generic_metadata_parser.py
+++ b/sample_metadata/parser/generic_metadata_parser.py
@@ -303,15 +303,15 @@ class GenericMetadataParser(GenericParser):
 
         filenames: List[str] = sum(await asyncio.gather(*filename_promises), [])
         fs = set(f.strip() for f in filenames if f and f.strip())
-        relevant_extensions = ('.cram', '.fastq.gz', '.bam')
+        relevant_extensions = ('.cram', '.crai', '.fq.gz', '.fastq.gz', '.bam', '.bai')
 
         def filename_filter(f):
             return any(f.endswith(ext) for ext in relevant_extensions)
 
         relevant_mapped_files = set(filter(filename_filter, self.filename_map.keys()))
 
-        missing_files = fs - relevant_mapped_files
-        files_in_search_path_not_in_map = relevant_mapped_files - fs
+        missing_files = relevant_mapped_files - fs
+        files_in_search_path_not_in_map = fs - relevant_mapped_files
 
         errors = []
 


### PR DESCRIPTION
A couple of fixes to the parser:

* `CloudHelper.populate_filename_map` referenced `self.filename_map` in the function that is used to initialise it, which led to an error;
* `CloudHelper._list_gcs_directory` didn't work with search prefixes ~deeper than the bucket root level~ on the bucket root level without trailing /, fixed it;
* In `GenericMetadataParser.check_files_covered_by_rows` the order of sets to determine missing/extra files seemed to be swapped. Also, not sure about the extension list there, should it import `generic_parser.FASTQ_EXTENSIONS`, `generic_parser.BAM_EXTENSIONS`, etc?