### PR TITLE
Handle case where sample doesn't exist in metamist

### DIFF
--- a/api/routes/sequence.py
+++ b/api/routes/sequence.py
@@ -94,9 +94,9 @@ async def update_sequence_from_sample_and_type(
 
 @router.patch(
     '/external_sample_id/{project}/{external_sample_id}/{sequence_type}',
-    operation_id='updateSequenceFromExternalSampleAndType',
+    operation_id='upsertSequenceFromExternalSampleAndType',
 )
-async def update_sequence_from_external_id_and_type(
+async def upsert_sequence_from_external_id_and_type(
     external_sample_id: str,
     sequence_type: SequenceType,
     sequence: SequenceUpdateModel,
@@ -106,7 +106,7 @@ async def update_sequence_from_external_id_and_type(
     """Update the latest sequence by sample_id and sequence type"""
     sequence_layer = SampleSequenceLayer(connection)
 
-    sequence_id = await sequence_layer.update_sequence_from_external_id_and_type(
+    sequence_id = await sequence_layer.upsert_sequence_from_external_id_and_type(
         external_sample_id=external_sample_id,
         sequence_type=sequence_type,
         status=sequence.status,

--- a/api/routes/sequence.py
+++ b/api/routes/sequence.py
@@ -93,7 +93,7 @@ async def update_sequence_from_sample_and_type(
 
 
 @router.patch(
-    '/external_sample_id/{external_sample_id}/{project}/{sequence_type}',
+    '/external_sample_id/{project}/{external_sample_id}/{sequence_type}',
     operation_id='updateSequenceFromExternalSampleAndType',
 )
 async def update_sequence_from_external_id_and_type(

--- a/api/routes/sequence.py
+++ b/api/routes/sequence.py
@@ -14,6 +14,8 @@ from db.python.layers.sequence import (
     SampleSequenceLayer,
     SequenceUpdateModel,
 )
+from models.enums import SampleType
+
 from models.models.sample import (
     sample_id_format,
     sample_id_transform_to_raw,
@@ -98,6 +100,7 @@ async def update_sequence_from_external_id_and_type(
     external_sample_id: str,
     sequence_type: SequenceType,
     sequence: SequenceUpdateModel,
+    sample_type: SampleType = None,
     connection: Connection = get_project_write_connection,
 ):
     """Update the latest sequence by sample_id and sequence type"""
@@ -108,6 +111,7 @@ async def update_sequence_from_external_id_and_type(
         sequence_type=sequence_type,
         status=sequence.status,
         meta=sequence.meta,
+        sample_type=sample_type,
     )
 
     return sequence_id

--- a/db/python/layers/sequence.py
+++ b/db/python/layers/sequence.py
@@ -315,7 +315,7 @@ class SampleSequenceLayer(BaseLayer):
 
         return sequence_id
 
-    async def update_sequence_from_external_id_and_type(
+    async def upsert_sequence_from_external_id_and_type(
         self,
         external_sample_id,
         sequence_type,

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -293,7 +293,7 @@ class ProjectPermissionsTable:
         if check_permissions:
             await self.check_project_creator_permissions(author)
 
-        _query = 'SELECT id, name, meta, gcp_id, dataset, read_secret_name, write_secret_name FROM project'
+        _query = 'SELECT id, name, gcp_id, dataset, read_secret_name, write_secret_name FROM project'
         rows = await self.connection.fetch_all(_query)
         return list(map(ProjectRow.from_db, rows))
 

--- a/db/python/tables/project.py
+++ b/db/python/tables/project.py
@@ -293,7 +293,7 @@ class ProjectPermissionsTable:
         if check_permissions:
             await self.check_project_creator_permissions(author)
 
-        _query = 'SELECT id, name, gcp_id, dataset, read_secret_name, write_secret_name FROM project'
+        _query = 'SELECT id, name, meta, gcp_id, dataset, read_secret_name, write_secret_name FROM project'
         rows = await self.connection.fetch_all(_query)
         return list(map(ProjectRow.from_db, rows))
 

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -120,7 +120,7 @@ class TestSequence(DbIsolatedTest):
             )
 
     @run_test_as_sync
-    async def test_update_sequence_from_external_id_and_type(self):
+    async def test_upsert_sequence_from_external_id_and_type(self):
         """Test updating a sequence from external id and type"""
 
         # Create a sample in this test database first, then grab
@@ -144,7 +144,7 @@ class TestSequence(DbIsolatedTest):
 
         # Call new endpoint to update sequence status and meta
         meta = {'batch': 1}
-        await self.seql.update_sequence_from_external_id_and_type(
+        await self.seql.upsert_sequence_from_external_id_and_type(
             external_sample_id=self.external_sample_id,
             sequence_type=SequenceType(self.sequence_type),
             status=SequenceStatus(new_status),
@@ -158,27 +158,18 @@ class TestSequence(DbIsolatedTest):
         self.assertEqual(meta, sequence.meta)
 
     @run_test_as_sync
-    async def test_new_sample_update_sequence_from_external_id_and_type(self):
+    async def test_new_sample_upsert_sequence_from_external_id_and_type(self):
         """Test updating a sequence from external id and type, where
         the sample does not already exist"""
 
         # Set up new sample
         external_sample_id = 'NEW_TEST123'
 
-        statuses = [
-            'received',
-            'sent-to-sequencing',
-            'completed-sequencing',
-            'completed-qc',
-            'failed-qc',
-            'uploaded',
-            'unknown',
-        ]
-        status = random.choice(statuses)
+        status = 'uploaded'
 
         # Call new endpoint to update sequence status and meta
         meta = {'batch': 2}
-        sequence_id = await self.seql.update_sequence_from_external_id_and_type(
+        sequence_id = await self.seql.upsert_sequence_from_external_id_and_type(
             external_sample_id=external_sample_id,
             sequence_type=SequenceType(self.sequence_type),
             status=SequenceStatus(status),

--- a/test/test_sequence.py
+++ b/test/test_sequence.py
@@ -149,9 +149,44 @@ class TestSequence(DbIsolatedTest):
             sequence_type=SequenceType(self.sequence_type),
             status=SequenceStatus(new_status),
             meta=meta,
+            sample_type=SampleType('blood'),
         )
 
         # validate new status and meta
         sequence = await self.seql.get_sequence_by_id(sequence_id)
         self.assertEqual(new_status, sequence.status.value)
+        self.assertEqual(meta, sequence.meta)
+
+    @run_test_as_sync
+    async def test_new_sample_update_sequence_from_external_id_and_type(self):
+        """Test updating a sequence from external id and type, where
+        the sample does not already exist"""
+
+        # Set up new sample
+        external_sample_id = 'NEW_TEST123'
+
+        statuses = [
+            'received',
+            'sent-to-sequencing',
+            'completed-sequencing',
+            'completed-qc',
+            'failed-qc',
+            'uploaded',
+            'unknown',
+        ]
+        status = random.choice(statuses)
+
+        # Call new endpoint to update sequence status and meta
+        meta = {'batch': 2}
+        sequence_id = await self.seql.update_sequence_from_external_id_and_type(
+            external_sample_id=external_sample_id,
+            sequence_type=SequenceType(self.sequence_type),
+            status=SequenceStatus(status),
+            meta=meta,
+            sample_type=SampleType('blood'),
+        )
+
+        # validate new status and meta
+        sequence = await self.seql.get_sequence_by_id(sequence_id)
+        self.assertEqual(status, sequence.status.value)
         self.assertEqual(meta, sequence.meta)


### PR DESCRIPTION
At present, update_sequence_from_external_id_and_type does not handle the case where the sample does not yet exist in metamist. 

FYI @violetbrina 