### PR TITLE
Fix Get Sequences End Point 

### DIFF
--- a/db/python/tables/sequence.py
+++ b/db/python/tables/sequence.py
@@ -434,7 +434,7 @@ class SampleSequencingTable(DbBase):
             SELECT {keys_str}
             FROM sample_sequencing sq
             INNER JOIN sample s ON sq.sample_id = s.id
-            INNER JOIN sample_sequencing_eid sqeid ON sq.id = sqeid.sequencing_id
+            LEFT OUTER JOIN sample_sequencing_eid sqeid ON sq.id = sqeid.sequencing_id
         """
         if where:
             _query += f' WHERE {" AND ".join(where)};'


### PR DESCRIPTION
Because all of the existing data in metamist do not have multiple external ids, the current get_sequences_by function fails. This PR handles sequences with/without multiple external ids.