### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,14 @@
 # requirements are for running the server
 cpg-utils
-requests==2.25.1
+requests==2.28.1
 google-auth==1.35.0
 google-cloud-secret-manager==2.8.0
 google-cloud-logging==2.7.0
 google-cloud-storage==1.43.0
-uvicorn==0.17.6
-fastapi[all]==0.78.0
+uvicorn==0.18.3
+fastapi[all]==0.85.1
 python-multipart==0.0.5
-databases[mysql]==0.4.3
-cryptography==36.0.1
+databases[mysql]==0.6.1
+SQLAlchemy==1.4.41
+cryptography==38.0.1
 python-dateutil==2.8.2


### PR DESCRIPTION
Would love to upgrade to Python 3.11, but it's not available in pyenv yet and I'm not super keen to install outside it to test.