### PR TITLE
Update project admin to nest seqr project types

### DIFF
--- a/web/src/admin/ProjectsAdmin.tsx
+++ b/web/src/admin/ProjectsAdmin.tsx
@@ -1,7 +1,12 @@
 import * as React from "react";
-import { ProjectApi, ProjectRow } from "../sm-api";
+import { ProjectApi, ProjectRow, SequenceType } from "../sm-api";
 
-import { Message, Button, Checkbox, Input } from "semantic-ui-react";
+import { Message, Button, Checkbox, Input, InputProps } from "semantic-ui-react";
+
+interface ControlledInputProps extends InputProps {
+    project: ProjectRow;
+    metaKey: string;
+}
 
 const ProjectsAdmin = (props: any) => {
     const [projects, setProjects] = React.useState<ProjectRow[]>([]);
@@ -46,10 +51,8 @@ const ProjectsAdmin = (props: any) => {
             .then(() => getProjects());
     };
 
-    const ControlledInput: React.FunctionComponent<{
-        project: ProjectRow;
-        metaKey: string;
-    }> = ({ project, metaKey, ...props }) => {
+
+    const ControlledInput: React.FunctionComponent<ControlledInputProps> = ({ project, metaKey, ...props }) => {
         // const projStateMeta: any = projectStateValue[project.name!]?.meta || {}
         const projectMeta: any = project?.meta || {};
         return (
@@ -59,7 +62,7 @@ const ProjectsAdmin = (props: any) => {
                 // label={metaKey}
                 defaultValue={projectMeta[metaKey]}
                 // onChange={(e) => setProjectMetaState({ [project.name!]: { meta: { ...projStateMeta, [metaKey]: e.target.value } } })}
-                onBlur={(e) => {
+                onBlur={(e: any) => {
                     const newValue = e.currentTarget.value;
                     if (newValue === projectMeta[metaKey]) {
                         console.log(
@@ -77,6 +80,8 @@ const ProjectsAdmin = (props: any) => {
         );
     };
 
+    const seqTypes = Object.values(SequenceType)
+
     return (
         <>
             <h1>Projects admin</h1>
@@ -92,35 +97,43 @@ const ProjectsAdmin = (props: any) => {
                     {projects.map((p) => {
                         // @ts-ignore
                         const meta: { [key: string]: any } = p?.meta || {};
-                        return (
-                            <tr key={p.id}>
-                                <td>{p.id}</td>
-                                <td>{p.name}</td>
-                                <td>{p.dataset}</td>
-                                <td>
-                                    <Checkbox
-                                        checked={meta?.is_seqr}
-                                        onChange={(e, data) =>
-                                            updateMetaValue(
-                                                p.name!,
-                                                "is_seqr",
-                                                data.checked
-                                            )
-                                        }
-                                    />
-                                </td>
-                                <td>
+
+                        const isSeqr = meta?.is_seqr || false
+                        const types = isSeqr ? seqTypes : [null]
+                        const rowSpan = isSeqr ? seqTypes.length : undefined
+
+                        return types.map((seqType, idx) => (
+                            <tr key={`${p.id}-${seqType}`}>
+                                {idx === 0 && (<>
+                                    <td rowSpan={rowSpan}>{p.id}</td>
+                                    <td rowSpan={rowSpan}>{p.name}</td>
+                                    <td rowSpan={rowSpan}>{p.dataset}</td>
+                                    <td rowSpan={rowSpan}>
+                                        <Checkbox
+                                            checked={meta?.is_seqr}
+                                            onChange={(e, data) =>
+                                                updateMetaValue(
+                                                    p.name!,
+                                                    "is_seqr",
+                                                    data.checked
+                                                )
+                                            }
+                                        />
+                                    </td>
+                                </>)}
+                                {!seqType && <td></td>}
+                                {!!seqType && (<td>
                                     <ControlledInput
-                                        key={`controlled-${p.name!}-seqr-guid}`}
+                                        key={`controlled-${p.name!}-${seqType}-seqr-guid}`}
                                         project={p}
-                                        metaKey="seqr_guid"
-                                        disabled={!p.meta?.is_seqr}
-                                        placeholder="Seqr GUID"
+                                        metaKey={`seqr-project-${seqType}`}
+                                        placeholder={`Seqr ${seqType} project GUID`}
+                                        label={seqType}
                                     />
-                                </td>
+                                </td>)}
                             </tr>
-                        );
-                    })}
+                        ))
+                    }).flat()}
                 </tbody>
             </table>
         </>

--- a/web/src/admin/ProjectsAdmin.tsx
+++ b/web/src/admin/ProjectsAdmin.tsx
@@ -62,7 +62,7 @@ const ProjectsAdmin = (props: any) => {
                 // label={metaKey}
                 defaultValue={projectMeta[metaKey]}
                 // onChange={(e) => setProjectMetaState({ [project.name!]: { meta: { ...projStateMeta, [metaKey]: e.target.value } } })}
-                onBlur={(e: any) => {
+                onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
                     const newValue = e.currentTarget.value;
                     if (newValue === projectMeta[metaKey]) {
                         console.log(


### PR DESCRIPTION
We use one seqr project per sequence type, change the UI to support this functionality dynamically based on SequenceType. Use `rowSpan` to keep things appearing in the same table.

Requires migration on release to rename existing projects: 

seqr_guid -> seqr-project-genome

```sql
UPDATE project 
SET meta = JSON_REMOVE(JSON_SET(meta, "$.seqr-project-genome", JSON_VALUE(meta, "$.seqr_guid")), "$.seqr_guid") 
WHERE JSON_EXISTS(meta, "$.seqr_guid")
FROM project;
```

Preview: 

<img width="731" alt="image" src="https://user-images.githubusercontent.com/22381693/198875507-645eeedd-4b7f-4966-913d-31fe1c6f353d.png">
