### PR TITLE
Small UI fixes

### DIFF
--- a/db/python/layers/sequence.py
+++ b/db/python/layers/sequence.py
@@ -87,7 +87,7 @@ class SampleSequenceLayer(BaseLayer):
         projects, sequences = await self.seqt.get_sequences_by(sample_ids=sample_ids)
 
         if (
-            check_project_ids and projects and sequences
+            check_project_ids and sequences
         ):  # Only do this check if a sample actually has associated sequences
             await self.ptable.check_access_to_project_ids(
                 self.author, projects, readonly=True

--- a/db/python/layers/sequence.py
+++ b/db/python/layers/sequence.py
@@ -86,7 +86,9 @@ class SampleSequenceLayer(BaseLayer):
         """
         projects, sequences = await self.seqt.get_sequences_by(sample_ids=sample_ids)
 
-        if check_project_ids:
+        if (
+            check_project_ids and projects and sequences
+        ):  # Only do this check if a sample actually has associated sequences
             await self.ptable.check_access_to_project_ids(
                 self.author, projects, readonly=True
             )

--- a/web/src/DetailedInfoPage.tsx
+++ b/web/src/DetailedInfoPage.tsx
@@ -60,7 +60,7 @@ enum SampleType {
 }
 
 interface Sample {
-    id: number | string;
+    id: string;
     external_id: string;
     participant_id?: number;
     active?: boolean;

--- a/web/src/DetailedInfoPage.tsx
+++ b/web/src/DetailedInfoPage.tsx
@@ -323,7 +323,6 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
     const safeValue = (value: any): string => {
         if (!value) return value;
         if (Array.isArray(value)) {
-            debugger;
             return value.map(safeValue).join(", ");
         }
         if (typeof value === "number") {
@@ -333,12 +332,10 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
             return value;
         }
         if (value && typeof value === "object" && !Array.isArray(value)) {
-            debugger;
             if (!!value.location && !!value.size) {
                 return `${value.location} (${formatBytes(value.size)})`;
             }
         }
-        debugger;
         return JSON.stringify(value);
     };
 
@@ -427,17 +424,14 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
                     .filter(([key, value]) =>
                         sampleFieldsToDisplay.includes(key)
                     )
-                    .map(([key, value]) =>
-                        value ? (
-                            <div key={`${key}-${value}`}>
-                                <b>{key}:</b> {value.toString()}
-                            </div>
-                        ) : (
-                            <React.Fragment
-                                key={`${key}-${value}`}
-                            ></React.Fragment>
-                        )
-                    )}
+                    .map(([key, value]) => (
+                        <div key={`${key}-${value}`}>
+                            <b>{key}:</b>{" "}
+                            {value != null
+                                ? value.toString()
+                                : "null/undefined"}
+                        </div>
+                    ))}
             </>
         );
     };
@@ -477,46 +471,42 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
         );
     };
 
-    const renderTitle = () => {
-        return (
-            <div
-                style={{
-                    borderBottom: `1px solid black`,
-                }}
-            >
-                {participants &&
-                    participants
-                        .filter(
-                            (item) => item.id === sampleInfo?.participant_id
-                        )
-                        .map((item) => {
-                            return (
-                                <React.Fragment key={item.external_id}>
-                                    <h1
-                                        style={{
-                                            display: "inline",
-                                        }}
-                                        key={`${item.external_id}`}
-                                    >
-                                        {`${item.external_id}\t`}
-                                    </h1>
-                                </React.Fragment>
-                            );
-                        })}
-                {sampleInfo && (
-                    <>
-                        <h3
-                            style={{
-                                display: "inline",
-                            }}
-                        >
-                            {`${sampleInfo?.id}\t${sampleInfo?.external_id}`}
-                        </h3>
-                    </>
-                )}
-            </div>
-        );
-    };
+    const renderTitle = (
+        <div
+            style={{
+                borderBottom: `1px solid black`,
+            }}
+        >
+            {participants &&
+                participants
+                    .filter((item) => item.id === sampleInfo?.participant_id)
+                    .map((item) => {
+                        return (
+                            <React.Fragment key={item.external_id}>
+                                <h1
+                                    style={{
+                                        display: "inline",
+                                    }}
+                                    key={`${item.external_id}`}
+                                >
+                                    {`${item.external_id}\t`}
+                                </h1>
+                            </React.Fragment>
+                        );
+                    })}
+            {sampleInfo && (
+                <>
+                    <h3
+                        style={{
+                            display: "inline",
+                        }}
+                    >
+                        {`${sampleInfo?.id}\t${sampleInfo?.external_id}`}
+                    </h3>
+                </>
+            )}
+        </div>
+    );
 
     return (
         <>
@@ -526,7 +516,7 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
             {projectName && !isLoading && !error && (
                 <>
                     <div className="detailedInfo">
-                        <div>{renderTitle()}</div>
+                        <div>{renderTitle}</div>
                         <br />
                         <div>{renderPedigreeSection()}</div>
                         <br />

--- a/web/src/DetailedInfoPage.tsx
+++ b/web/src/DetailedInfoPage.tsx
@@ -72,7 +72,22 @@ interface Sample {
 
 const sampleFieldsToDisplay = ["active", "type", "participant_id"];
 
-export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
+export class DetailedInfoPage extends React.Component<{}, { error?: Error }> {
+    state = {};
+    static getDerivedStateFromError(error: Error) {
+        // Update state so the next render will show the fallback UI.
+        return { error: error };
+    }
+
+    render() {
+        if (this.state.error) {
+            return <p>{this.state.error.toString()}</p>;
+        }
+        return <DetailedInfoPage_ />; /* eslint react/jsx-pascal-case: 0 */
+    }
+}
+
+export const DetailedInfoPage_: React.FunctionComponent<{}> = () => {
     const { projectName, sampleName } = useParams();
     const navigate = useNavigate();
     const [samples, setSamples] = React.useState();
@@ -427,9 +442,7 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
                     .map(([key, value]) => (
                         <div key={`${key}-${value}`}>
                             <b>{key}:</b>{" "}
-                            {value != null
-                                ? value.toString()
-                                : "null/undefined"}
+                            {value?.toString() ?? <em>no value</em>}
                         </div>
                     ))}
             </>

--- a/web/src/DetailedInfoPage.tsx
+++ b/web/src/DetailedInfoPage.tsx
@@ -162,7 +162,6 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
             .getSequencesBySampleIds([sampleInfo.id.toString()])
             .then((resp) => {
                 setSequenceInfo(resp.data[0]);
-                setIsLoading(false);
             })
             .catch((er) => {
                 setError(er.message);
@@ -392,6 +391,133 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
         });
     };
 
+    const renderSeqSection = () => {
+        if (!sample || !sequenceInfo) {
+            return <></>;
+        }
+        return (
+            <>
+                <h4
+                    style={{
+                        borderBottom: `1px solid black`,
+                    }}
+                >
+                    Sequence Information
+                </h4>
+                {renderSeqInfo(sequenceInfo)}
+                {prepReadMetadata(sequenceInfo.meta || {})}
+            </>
+        );
+    };
+
+    const renderSampleSection = () => {
+        if (!sample || !sampleInfo) {
+            return <></>;
+        }
+        return (
+            <>
+                <h4
+                    style={{
+                        borderBottom: `1px solid black`,
+                    }}
+                >
+                    Sample Information
+                </h4>
+                {Object.entries(sampleInfo)
+                    .filter(([key, value]) =>
+                        sampleFieldsToDisplay.includes(key)
+                    )
+                    .map(([key, value]) =>
+                        value ? (
+                            <div key={`${key}-${value}`}>
+                                <b>{key}:</b> {value.toString()}
+                            </div>
+                        ) : (
+                            <React.Fragment
+                                key={`${key}-${value}`}
+                            ></React.Fragment>
+                        )
+                    )}
+            </>
+        );
+    };
+
+    const renderPedigreeSection = () => {
+        if (!sample || !pedigree) {
+            return <></>;
+        }
+        return (
+            <>
+                {pedigree
+                    .filter((item) => item.individual_id === selectedExternalID)
+                    .map((item) => (
+                        <React.Fragment
+                            key={`${item.individual_id}-${item.maternal_id}-${item.paternal_id}`}
+                        >
+                            {item.paternal_id &&
+                                item.maternal_id &&
+                                drawTrio(
+                                    item.paternal_id,
+                                    pedigree?.find(
+                                        (i) =>
+                                            i.individual_id === item.paternal_id
+                                    )!.affected,
+                                    item.maternal_id,
+                                    pedigree?.find(
+                                        (i) =>
+                                            i.individual_id === item.maternal_id
+                                    )!.affected,
+                                    item.individual_id,
+                                    item.affected,
+                                    item.sex
+                                )}
+                        </React.Fragment>
+                    ))}
+            </>
+        );
+    };
+
+    const renderTitle = () => {
+        return (
+            <div
+                style={{
+                    borderBottom: `1px solid black`,
+                }}
+            >
+                {participants &&
+                    participants
+                        .filter(
+                            (item) => item.id === sampleInfo?.participant_id
+                        )
+                        .map((item) => {
+                            return (
+                                <React.Fragment key={item.external_id}>
+                                    <h1
+                                        style={{
+                                            display: "inline",
+                                        }}
+                                        key={`${item.external_id}`}
+                                    >
+                                        {`${item.external_id}\t`}
+                                    </h1>
+                                </React.Fragment>
+                            );
+                        })}
+                {sampleInfo && (
+                    <>
+                        <h3
+                            style={{
+                                display: "inline",
+                            }}
+                        >
+                            {`${sampleInfo?.id}\t${sampleInfo?.external_id}`}
+                        </h3>
+                    </>
+                )}
+            </div>
+        );
+    };
+
     return (
         <>
             <br />
@@ -400,136 +526,13 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
             {projectName && !isLoading && !error && (
                 <>
                     <div className="detailedInfo">
-                        {sample && (
-                            <>
-                                <div
-                                    style={{
-                                        borderBottom: `1px solid black`,
-                                    }}
-                                >
-                                    {participants &&
-                                        participants
-                                            .filter(
-                                                (item) =>
-                                                    item.id ===
-                                                    sampleInfo?.participant_id
-                                            )
-                                            .map((item) => {
-                                                return (
-                                                    <React.Fragment
-                                                        key={item.external_id}
-                                                    >
-                                                        <h1
-                                                            style={{
-                                                                display:
-                                                                    "inline",
-                                                            }}
-                                                            key={`${item.external_id}`}
-                                                        >
-                                                            {`${item.external_id}\t`}
-                                                        </h1>
-                                                        <h3
-                                                            style={{
-                                                                display:
-                                                                    "inline",
-                                                            }}
-                                                        >
-                                                            {`${sampleInfo?.id}\t
-                                                                ${sampleInfo?.external_id}`}
-                                                        </h3>
-                                                    </React.Fragment>
-                                                );
-                                            })}
-                                </div>
-                                <br />
-                                <div>
-                                    {sample && (
-                                        <>
-                                            {pedigree &&
-                                                pedigree
-                                                    .filter(
-                                                        (item) =>
-                                                            item.individual_id ===
-                                                            selectedExternalID
-                                                    )
-                                                    .map((item) => (
-                                                        <React.Fragment
-                                                            key={`${item.individual_id}-${item.maternal_id}-${item.paternal_id}`}
-                                                        >
-                                                            {item.paternal_id &&
-                                                                item.maternal_id &&
-                                                                drawTrio(
-                                                                    item.paternal_id,
-                                                                    pedigree?.find(
-                                                                        (i) =>
-                                                                            i.individual_id ===
-                                                                            item.paternal_id
-                                                                    )!.affected,
-                                                                    item.maternal_id,
-                                                                    pedigree?.find(
-                                                                        (i) =>
-                                                                            i.individual_id ===
-                                                                            item.maternal_id
-                                                                    )!.affected,
-                                                                    item.individual_id,
-                                                                    item.affected,
-                                                                    item.sex
-                                                                )}
-                                                        </React.Fragment>
-                                                    ))}
-                                        </>
-                                    )}
-                                </div>
-                                <div>
-                                    {sample && (
-                                        <>
-                                            <h4
-                                                style={{
-                                                    borderBottom: `1px solid black`,
-                                                }}
-                                            >
-                                                Sample Information
-                                            </h4>
-                                            {sampleInfo &&
-                                                Object.entries(sampleInfo)
-                                                    .filter(([key, value]) =>
-                                                        sampleFieldsToDisplay.includes(
-                                                            key
-                                                        )
-                                                    )
-                                                    .map(([key, value]) => (
-                                                        <div
-                                                            key={`${key}-${value}`}
-                                                        >
-                                                            <b>{key}:</b>{" "}
-                                                            {value.toString()}
-                                                        </div>
-                                                    ))}
-                                        </>
-                                    )}
-                                </div>
-                                <br />
-                                <div>
-                                    {sample && (
-                                        <>
-                                            <h4
-                                                style={{
-                                                    borderBottom: `1px solid black`,
-                                                }}
-                                            >
-                                                Sequence Information
-                                            </h4>
-                                            {sequenceInfo &&
-                                                renderSeqInfo(sequenceInfo)}
-                                            {sequenceInfo &&
-                                                prepReadMetadata(
-                                                    sequenceInfo.meta || {}
-                                                )}
-                                        </>
-                                    )}
-                                </div>
-                            </>
-                        )}
+                        <div>{renderTitle()}</div>
+                        <br />
+                        <div>{renderPedigreeSection()}</div>
+                        <br />
+                        <div>{renderSampleSection()}</div>
+                        <br />
+                        <div>{renderSeqSection()}</div>
                     </div>
                 </>
             )}

--- a/web/src/DetailedInfoPage.tsx
+++ b/web/src/DetailedInfoPage.tsx
@@ -9,7 +9,7 @@ import {
     ParticipantApi,
     SequenceApi,
     // ParticipantModel,
-    Sample,
+    // Sample,
     // SampleSequencing,
 } from "./sm-api/api";
 import { Table } from "semantic-ui-react";
@@ -37,21 +37,37 @@ interface SequenceMeta {
 
 // temporary
 interface ParticipantModel {
-    id: number
-    external_id: string
-    reported_sex?: number
-    reported_gender?: string
-    karyotype?: string
-    meta: { [key: string]: any }
+    id: number;
+    external_id: string;
+    reported_sex?: number;
+    reported_gender?: string;
+    karyotype?: string;
+    meta: { [key: string]: any };
 }
 
 interface SampleSequencing {
-    id: number
-    external_ids?: { [name: string]: string }
-    sample_id: string
-    type: string
-    meta?: SequenceMeta
-    status: string
+    id: number;
+    external_ids?: { [name: string]: string };
+    sample_id: string;
+    type: string;
+    meta?: SequenceMeta;
+    status: string;
+}
+
+enum SampleType {
+    BLOOD = "blood",
+    SALIVA = "saliva",
+}
+
+interface Sample {
+    id: number | string;
+    external_id: string;
+    participant_id?: number;
+    active?: boolean;
+    meta?: { [key: string]: any };
+    type?: SampleType;
+    project?: number;
+    author?: string;
 }
 
 const sampleFieldsToDisplay = ["active", "type", "participant_id"];
@@ -106,8 +122,7 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
                 setSampleInfo(resp.data);
                 setSelectedExternalID(
                     participants.find(
-                        (item) =>
-                            item.id.toString() === resp.data.participant_id
+                        (item) => item.id === resp.data.participant_id
                     )?.external_id
                 );
             })
@@ -193,8 +208,9 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
 
         const i = Math.floor(Math.log(bytes) / Math.log(k));
 
-        return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]
-            }`;
+        return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${
+            sizes[i]
+        }`;
     };
 
     const prepReadMetadata = (data: SequenceMeta) => {
@@ -306,28 +322,26 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
     }, [projectName, samples, sampleName]);
 
     const safeValue = (value: any): string => {
-        if (!value) return value
+        if (!value) return value;
         if (Array.isArray(value)) {
-            debugger
-            return value.map(safeValue).join(", ")
+            debugger;
+            return value.map(safeValue).join(", ");
         }
         if (typeof value === "number") {
-            return value.toString()
+            return value.toString();
         }
         if (typeof value === "string") {
-            return value
+            return value;
         }
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-            debugger
+        if (value && typeof value === "object" && !Array.isArray(value)) {
+            debugger;
             if (!!value.location && !!value.size) {
-                return `${value.location} (${formatBytes(value.size)})`
+                return `${value.location} (${formatBytes(value.size)})`;
             }
-
         }
-        debugger
-        return JSON.stringify(value)
-
-    }
+        debugger;
+        return JSON.stringify(value);
+    };
 
     const renderSeqInfo = (seqInfo: SampleSequencing) => {
         return Object.entries(seqInfo).map(([key, value]) => {
@@ -352,18 +366,24 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
                 return Object.entries(seqInfo.meta!)
                     .filter(([k1, v1]) => k1 !== "reads")
                     .map(([k1, v1]) => {
-                        if (Array.isArray(v1) && v1.filter(v => !!v.location && !!v.size).length === v1.length) {
+                        if (
+                            Array.isArray(v1) &&
+                            v1.filter((v) => !!v.location && !!v.size)
+                                .length === v1.length
+                        ) {
                             // all are files coincidentally
-                            return renderReadsMetadata(value as File[], key)
+                            return renderReadsMetadata(value as File[], key);
                         }
-                        const stringifiedValue = safeValue(v1)
-                        return (<div key={`${k1}-${stringifiedValue}`}>
-                            <b>{k1}:</b> {stringifiedValue}
-                        </div>)
+                        const stringifiedValue = safeValue(v1);
+                        return (
+                            <div key={`${k1}-${stringifiedValue}`}>
+                                <b>{k1}:</b> {stringifiedValue}
+                            </div>
+                        );
                     });
             }
 
-            const stringifiedValue = safeValue(value)
+            const stringifiedValue = safeValue(value);
             return (
                 <div key={`${key}-${stringifiedValue}`}>
                     <b>{key}:</b> {stringifiedValue}
@@ -391,7 +411,7 @@ export const DetailedInfoPage: React.FunctionComponent<{}> = () => {
                                         participants
                                             .filter(
                                                 (item) =>
-                                                    item.id.toString() ===
+                                                    item.id ===
                                                     sampleInfo?.participant_id
                                             )
                                             .map((item) => {

--- a/web/src/project/ProjectSummary.tsx
+++ b/web/src/project/ProjectSummary.tsx
@@ -101,8 +101,6 @@ export const ProjectSummary = () => {
         pageNumber,
     ]);
 
-    let table: React.ReactElement = <></>;
-
     const totalPageNumbers = Math.ceil(
         (summary?.total_samples || 0) / pageLimit
     );
@@ -126,7 +124,7 @@ export const ProjectSummary = () => {
                     {summary?.total_samples} samples)
                 </span>
             )}
-            {summary?._links?.token && (
+            {pageNumber < totalPageNumbers && (
                 <Button
                     disabled={isLoading}
                     onClick={() => {
@@ -138,174 +136,163 @@ export const ProjectSummary = () => {
             )}
         </>
     );
-    // }
 
-    if (error) {
-        table = (
-            <p>
-                <em>An error occurred when fetching samples: {error}</em>
-            </p>
-        );
-    } else if (!summary) {
-        if (projectName) {
-            table = <p>Loading...</p>;
-        } else {
-            table = (
+    const renderGrid = () => {
+        if (error) {
+            return (
                 <p>
-                    <em>Please select a project</em>
+                    <em>An error occurred when fetching samples: {error}</em>
                 </p>
             );
         }
-    } else {
+        if (!summary) {
+            if (projectName) {
+                return <p>Loading...</p>;
+            } else {
+                return (
+                    <p>
+                        <em>Please select a project</em>
+                    </p>
+                );
+            }
+        }
         if (summary.participants.length === 0) {
-            table = (
+            return (
                 <p>
                     <em>No samples</em>
                 </p>
             );
-        } else {
-            const headers = [
-                "Family ID",
-                ...summary.participant_keys.map((field) => field[1]),
-                ...summary.sample_keys.map((field) => field[1]),
-                ...summary.sequence_keys.map((field) => "sequence." + field[1]),
-            ];
-
-            table = (
-                <Table celled>
-                    <Table.Header>
-                        <Table.Row>
-                            {headers.map((k, i) => (
-                                <Table.HeaderCell key={`${k}-${i}`}>
-                                    {k}
-                                </Table.HeaderCell>
-                            ))}
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {summary.participants.map((p, pidx) =>
-                            p.samples.map((s, sidx) => {
-                                // @ts-ignore
-                                const backgroundColor =
-                                    pidx % 2 === 0
-                                        ? "white"
-                                        : "var(--bs-table-striped-bg)";
-                                const lengthOfParticipant = p.samples
-                                    .map((s) => s.sequences.length)
-                                    .reduce((a, b) => a + b, 0);
-                                return s.sequences.map((seq, seqidx) => {
-                                    const isFirstOfGroup =
-                                        sidx === 0 && seqidx === 0;
-                                    return (
-                                        <Table.Row
-                                            key={`${p.external_id}-${s.id}-${seq.id}`}
-                                        >
-                                            {isFirstOfGroup && (
-                                                <Table.Cell
-                                                    style={{ backgroundColor }}
-                                                    rowSpan={
-                                                        lengthOfParticipant
-                                                    }
-                                                >
-                                                    {p.families
-                                                        .map(
-                                                            (f) => f.external_id
-                                                        )
-                                                        .join(", ")}
-                                                </Table.Cell>
-                                            )}
-                                            {isFirstOfGroup &&
-                                                summary.participant_keys.map(
-                                                    ([k, dn]) => (
-                                                        <Table.Cell
-                                                            style={{
-                                                                backgroundColor,
-                                                            }}
-                                                            key={
-                                                                p.id +
-                                                                "participant." +
-                                                                k
-                                                            }
-                                                            rowSpan={
-                                                                lengthOfParticipant
-                                                            }
-                                                        >
-                                                            {sanitiseValue(
-                                                                _.get(p, k)
-                                                            )}
-                                                        </Table.Cell>
-                                                    )
-                                                )}
-                                            {seqidx === 0 &&
-                                                summary.sample_keys.map(
-                                                    ([k, dn]) => (
-                                                        <Table.Cell
-                                                            style={{
-                                                                backgroundColor,
-                                                            }}
-                                                            key={
-                                                                s.id +
-                                                                "sample." +
-                                                                k
-                                                            }
-                                                            rowSpan={
-                                                                s.sequences
-                                                                    .length
-                                                            }
-                                                        >
-                                                            {k ===
-                                                                "external_id" ||
-                                                            k === "id" ? (
-                                                                <SampleLink
-                                                                    id={s.id}
-                                                                    projectName={
-                                                                        projectName
-                                                                    }
-                                                                >
-                                                                    {sanitiseValue(
-                                                                        _.get(
-                                                                            s,
-                                                                            k
-                                                                        )
-                                                                    )}
-                                                                </SampleLink>
-                                                            ) : (
-                                                                sanitiseValue(
-                                                                    _.get(s, k)
-                                                                )
-                                                            )}
-                                                        </Table.Cell>
-                                                    )
-                                                )}
-                                            {seq &&
-                                                summary.sequence_keys.map(
-                                                    ([k, dn]) => (
-                                                        <Table.Cell
-                                                            style={{
-                                                                backgroundColor,
-                                                            }}
-                                                            key={
-                                                                s.id +
-                                                                "sequence." +
-                                                                k
-                                                            }
-                                                        >
-                                                            {sanitiseValue(
-                                                                _.get(seq, k)
-                                                            )}
-                                                        </Table.Cell>
-                                                    )
-                                                )}
-                                        </Table.Row>
-                                    );
-                                });
-                            })
-                        )}
-                    </Table.Body>
-                </Table>
-            );
         }
-    }
+        const headers = [
+            "Family ID",
+            ...summary.participant_keys.map((field) => field[1]),
+            ...summary.sample_keys.map((field) => field[1]),
+            ...summary.sequence_keys.map((field) => "sequence." + field[1]),
+        ];
+
+        return (
+            <Table celled>
+                <Table.Header>
+                    <Table.Row>
+                        {headers.map((k, i) => (
+                            <Table.HeaderCell key={`${k}-${i}`}>
+                                {k}
+                            </Table.HeaderCell>
+                        ))}
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {summary.participants.map((p, pidx) =>
+                        p.samples.map((s, sidx) => {
+                            // @ts-ignore
+                            const backgroundColor =
+                                pidx % 2 === 0
+                                    ? "white"
+                                    : "var(--bs-table-striped-bg)";
+                            const lengthOfParticipant = p.samples
+                                .map((s) => s.sequences.length)
+                                .reduce((a, b) => a + b, 0);
+                            return s.sequences.map((seq, seqidx) => {
+                                const isFirstOfGroup =
+                                    sidx === 0 && seqidx === 0;
+                                return (
+                                    <Table.Row
+                                        key={`${p.external_id}-${s.id}-${seq.id}`}
+                                    >
+                                        {isFirstOfGroup && (
+                                            <Table.Cell
+                                                style={{ backgroundColor }}
+                                                rowSpan={lengthOfParticipant}
+                                            >
+                                                {p.families
+                                                    .map((f) => f.external_id)
+                                                    .join(", ")}
+                                            </Table.Cell>
+                                        )}
+                                        {isFirstOfGroup &&
+                                            summary.participant_keys.map(
+                                                ([k, dn]) => (
+                                                    <Table.Cell
+                                                        style={{
+                                                            backgroundColor,
+                                                        }}
+                                                        key={
+                                                            p.id +
+                                                            "participant." +
+                                                            k
+                                                        }
+                                                        rowSpan={
+                                                            lengthOfParticipant
+                                                        }
+                                                    >
+                                                        {sanitiseValue(
+                                                            _.get(p, k)
+                                                        )}
+                                                    </Table.Cell>
+                                                )
+                                            )}
+                                        {seqidx === 0 &&
+                                            summary.sample_keys.map(
+                                                ([k, dn]) => (
+                                                    <Table.Cell
+                                                        style={{
+                                                            backgroundColor,
+                                                        }}
+                                                        key={
+                                                            s.id + "sample." + k
+                                                        }
+                                                        rowSpan={
+                                                            s.sequences.length
+                                                        }
+                                                    >
+                                                        {k === "external_id" ||
+                                                        k === "id" ? (
+                                                            <SampleLink
+                                                                id={s.id}
+                                                                projectName={
+                                                                    projectName
+                                                                }
+                                                            >
+                                                                {sanitiseValue(
+                                                                    _.get(s, k)
+                                                                )}
+                                                            </SampleLink>
+                                                        ) : (
+                                                            sanitiseValue(
+                                                                _.get(s, k)
+                                                            )
+                                                        )}
+                                                    </Table.Cell>
+                                                )
+                                            )}
+                                        {seq &&
+                                            summary.sequence_keys.map(
+                                                ([k, dn]) => (
+                                                    <Table.Cell
+                                                        style={{
+                                                            backgroundColor,
+                                                        }}
+                                                        key={
+                                                            s.id +
+                                                            "sequence." +
+                                                            k
+                                                        }
+                                                    >
+                                                        {sanitiseValue(
+                                                            _.get(seq, k)
+                                                        )}
+                                                    </Table.Cell>
+                                                )
+                                            )}
+                                    </Table.Row>
+                                );
+                            });
+                        })
+                    )}
+                </Table.Body>
+            </Table>
+        );
+    };
 
     const titleCase = (s: string) => {
         return s[0].toUpperCase() + s.slice(1).toLowerCase();
@@ -384,7 +371,7 @@ export const ProjectSummary = () => {
                     {pageOptions}
                 </div>
             )}
-            {table}
+            {renderGrid()}
             {pageOptions}
         </>
     );


### PR DESCRIPTION
Fixed missing title on sample page
Don't try to render null fields on sample page
Don't render next page button when only 1 page
Added missing Sample interface
Don't throw error when a sample has no associated sequences
Remove excessive nesting; instead return early (general code cleanup)
