### PR TITLE
Add alternate implementation for file_exists

### DIFF
--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -99,6 +99,8 @@ class CloudHelper:
         """Determines whether a file exists"""
         path = self.file_path(filename)
         if path.startswith('gs://'):
+            # add a specific case for GCS as the AnyPath implementation calls
+            # bucket.get_blob which triggers a read (which humans don't have)
             blob = self.get_gcs_blob(path)
             return blob is not None
 

--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -97,7 +97,12 @@ class CloudHelper:
 
     async def file_exists(self, filename: str) -> bool:
         """Determines whether a file exists"""
-        return AnyPath(self.file_path(filename)).exists()
+        path = self.file_path(filename)
+        if path.startswith('gs://'):
+            blob = self.get_gcs_blob(filename)
+            return blob is not None
+
+        return AnyPath(path).exists()
 
     async def file_size(self, filename) -> int:
         """Get size of file in bytes"""

--- a/sample_metadata/parser/cloudhelper.py
+++ b/sample_metadata/parser/cloudhelper.py
@@ -100,7 +100,7 @@ class CloudHelper:
         path = self.file_path(filename)
         if path.startswith('gs://'):
             # add a specific case for GCS as the AnyPath implementation calls
-            # bucket.get_blob which triggers a read (which humans don't have)
+            # bucket.get_blob which triggers a read (which humans are not permitted)
             blob = self.get_gcs_blob(path)
             return blob is not None
 


### PR DESCRIPTION
- get_gcs_blob uses list_blobs and returns None when a blob with path name doesn't exist.

Implementation:

```python
    async def get_gcs_blob(self, filename: str) -> storage.Blob:
        """Convenience function for getting blob from fully qualified GCS path"""
        if not filename.startswith(self.GCS_PREFIX):
            raise ValueError('No blob available')

        bucket_name, path = filename[5:].split('/', maxsplit=1)
        bucket = self.get_gcs_bucket(bucket_name)

        # the next few lines are equiv to `bucket.get_blob(path)`
        # but without requiring storage.objects.get permission
        blobs = list(self.gcs_client.list_blobs(bucket, prefix=path))
        # first where r.name == path (or None)
        return next((r for r in blobs if r.name == path), None)
```