### PR TITLE
Add reference option to  in sample map parser

### DIFF
--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -46,6 +46,10 @@ logger.setLevel(logging.INFO)
     help='Search path to search for files within',
 )
 @click.option(
+    '--ref',
+    help='default_reference_assembly_location',
+)
+@click.option(
     '--dry-run', is_flag=True, help='Just prepare the run, without comitting it'
 )
 @click.option(
@@ -65,6 +69,7 @@ async def main(
     confirm=False,
     dry_run=False,
     allow_extra_files_in_search_path=False,
+    ref=None
 ):
     """Run script from CLI arguments"""
     if not manifests:
@@ -80,6 +85,7 @@ async def main(
         default_sequence_type=default_sequence_type,
         search_locations=search_path,
         allow_extra_files_in_search_path=allow_extra_files_in_search_path,
+        default_reference_assembly_location=ref
     )
     for manifest in manifests:
         logger.info(f'Importing {manifest}')

--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -69,7 +69,7 @@ async def main(
     confirm=False,
     dry_run=False,
     allow_extra_files_in_search_path=False,
-    ref=None
+    ref=None,
 ):
     """Run script from CLI arguments"""
     if not manifests:
@@ -85,7 +85,7 @@ async def main(
         default_sequence_type=default_sequence_type,
         search_locations=search_path,
         allow_extra_files_in_search_path=allow_extra_files_in_search_path,
-        default_reference_assembly_location=ref
+        default_reference_assembly_location=ref,
     )
     for manifest in manifests:
         logger.info(f'Importing {manifest}')

--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -47,7 +47,7 @@ logger.setLevel(logging.INFO)
 )
 @click.option(
     '--ref',
-    help='default_reference_assembly_location',
+    help='Path to genome reference used for crams. Required when ingesting crams. ',
 )
 @click.option(
     '--dry-run', is_flag=True, help='Just prepare the run, without comitting it'


### PR DESCRIPTION
Allow a path to a reference genome to be set in the sample map parser script. This is needed for ingest of cram files.