### PR TITLE
Add default_sequence_technology to parser

### DIFF
--- a/sample_metadata/parser/sample_file_map_parser.py
+++ b/sample_metadata/parser/sample_file_map_parser.py
@@ -82,8 +82,9 @@ class SampleFileMapParser(GenericMetadataParser):
         project: str,
         default_sequence_type='genome',
         default_sample_type='blood',
+        default_sequence_technology='short-read',
         allow_extra_files_in_search_path=False,
-        default_reference_assembly_location: str = None,
+        default_reference_assembly_location: str | None = None,
     ):
         super().__init__(
             search_locations=search_locations,
@@ -95,6 +96,7 @@ class SampleFileMapParser(GenericMetadataParser):
             seq_type_column=SEQ_TYPE_COL_NAME,
             default_sequence_type=default_sequence_type,
             default_sample_type=default_sample_type,
+            default_sequence_technology=default_sequence_technology,
             default_reference_assembly_location=default_reference_assembly_location,
             participant_meta_map={},
             sample_meta_map={},
@@ -112,6 +114,7 @@ class SampleFileMapParser(GenericMetadataParser):
 )
 @click.option('--default-sample-type', default='blood')
 @click.option('--default-sequence-type', default='wgs')
+@click.option('--default-sequence-technology', default='short-read')
 @click.option(
     '--confirm', is_flag=True, help='Confirm with user input before updating server'
 )
@@ -146,6 +149,7 @@ async def main(
     project,
     default_sample_type='blood',
     default_sequence_type='genome',
+    default_sequence_technology='short-read',
     default_reference_assembly: str = None,
     confirm=False,
     dry_run=False,
@@ -163,6 +167,7 @@ async def main(
         project=project,
         default_sample_type=default_sample_type,
         default_sequence_type=default_sequence_type,
+        default_sequence_technology=default_sequence_technology,
         search_locations=search_path,
         allow_extra_files_in_search_path=allow_extra_files_in_search_path,
         default_reference_assembly_location=default_reference_assembly,

--- a/scripts/parse_sample_file_map.py
+++ b/scripts/parse_sample_file_map.py
@@ -36,6 +36,7 @@ logger.setLevel(logging.INFO)
 )
 @click.option('--default-sample-type', default='blood')
 @click.option('--default-sequence-type', default='wgs')
+@click.option('--default-sequence-technology', default='short-read')
 @click.option(
     '--confirm', is_flag=True, help='Confirm with user input before updating server'
 )
@@ -66,6 +67,7 @@ async def main(
     project,
     default_sample_type='blood',
     default_sequence_type='wgs',
+    default_sequence_technology='short-read',
     confirm=False,
     dry_run=False,
     allow_extra_files_in_search_path=False,
@@ -83,6 +85,7 @@ async def main(
         project=project,
         default_sample_type=default_sample_type,
         default_sequence_type=default_sequence_type,
+        default_sequence_technology=default_sequence_technology,
         search_locations=search_path,
         allow_extra_files_in_search_path=allow_extra_files_in_search_path,
         default_reference_assembly_location=ref,


### PR DESCRIPTION
Sequences are currently being ingested with a null technology field, resulting in a [type error](https://batch.hail.populationgenomics.org.au/batches/420919/jobs/1) when read by the api. This PR sets the default_sequence_technology in sample map parsers to 'short-read'.

This does not address why records could be written to the db with a null technology field. @illusional I assume we should add not null constraint be added to the db, or handling of null in the API?
