### PR TITLE
Dim mode for swagger

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -16,7 +16,7 @@ const Routes: React.FunctionComponent = () => (
             <Route path=":id" element={<DocumentationArticle />} />
         </Route>
 
-        <Route path="/swagger" element={<SwaggerUI url="/openapi.json" />} />
+        <Route path="/swagger" element={<SwaggerUI url="/openapi.json" tryItOutEnabled={true} />} />
 
         <Route path="/project/">
             <Route

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -160,3 +160,12 @@ blockquote {
 [class^='language-'] {
     border: none;
 }
+
+/* poor man's dark mode: https://github.com/swagger-api/swagger-ui/issues/5327#issuecomment-742375520 */
+.swagger-ui {
+    filter: invert(88%) hue-rotate(180deg);
+}
+
+.swagger-ui .highlight-code {
+    filter: invert(100%) hue-rotate(180deg);
+}


### PR DESCRIPTION
I can't work out how to change the `/docs` url that fastapi puts out, but swagger itself doesn't support dark mode.