### PR TITLE
Fix sample ids in get_sequence_by_criteria 

### DIFF
--- a/api/routes/sequence.py
+++ b/api/routes/sequence.py
@@ -149,8 +149,8 @@ async def get_sequences_by_criteria(
         else None,
     )
 
-    for sequence_group in result:
-        sequence_group.sample_id = sample_id_format(sequence_group.sample_id)
+    for sequence in result:
+        sequence.sample_id = sample_id_format(sequence.sample_id)
 
     return result
 

--- a/api/routes/sequence.py
+++ b/api/routes/sequence.py
@@ -149,6 +149,9 @@ async def get_sequences_by_criteria(
         else None,
     )
 
+    for sequence_group in result:
+        sequence_group.sample_id = sample_id_format(sequence_group.sample_id)
+
     return result
 
 


### PR DESCRIPTION
Previously the raw ids were returned instead of the full CPG identifiers. 