### PR TITLE
Sequence date added field

### DIFF
--- a/sample_metadata/parser/generic_parser.py
+++ b/sample_metadata/parser/generic_parser.py
@@ -1221,6 +1221,8 @@ class GenericParser(
         """Takes filename, returns formed CWL dictionary"""
         _checksum = checksum
         file_size = None
+        datetime_added = None
+        file_location = self.file_path(filename)
 
         if not self.skip_checking_gcs_objects:
             if not _checksum:
@@ -1231,13 +1233,15 @@ class GenericParser(
                         _checksum = f'md5:{contents.strip()}'
 
             file_size = await self.file_size(filename)
+            datetime_added = await self.get_gcs_blob(file_location).time_created
 
         d = {
-            'location': self.file_path(filename),
+            'location': file_location,
             'basename': os.path.basename(filename),
             'class': 'File',
             'checksum': _checksum,
             'size': file_size,
+            'datetime_added': datetime_added
         }
 
         if secondary_files:

--- a/sample_metadata/parser/generic_parser.py
+++ b/sample_metadata/parser/generic_parser.py
@@ -1239,7 +1239,7 @@ class GenericParser(
             'class': 'File',
             'checksum': _checksum,
             'size': file_size,
-            'datetime_added': datetime_added
+            'datetime_added': datetime_added.isoformat() if datetime_added else None
         }
 
         if secondary_files:

--- a/sample_metadata/parser/generic_parser.py
+++ b/sample_metadata/parser/generic_parser.py
@@ -1222,7 +1222,6 @@ class GenericParser(
         _checksum = checksum
         file_size = None
         datetime_added = None
-        file_location = self.file_path(filename)
 
         if not self.skip_checking_gcs_objects:
             if not _checksum:
@@ -1232,11 +1231,10 @@ class GenericParser(
                     if contents:
                         _checksum = f'md5:{contents.strip()}'
 
-            file_size, file_blob = await asyncio.gather(self.file_size(filename), self.get_gcs_blob(file_location))
-            datetime_added = file_blob.time_created
+            file_size, datetime_added = await asyncio.gather(self.file_size(filename), self.datetime_added(filename))
 
         d = {
-            'location': file_location,
+            'location': self.file_path(filename),
             'basename': os.path.basename(filename),
             'class': 'File',
             'checksum': _checksum,

--- a/sample_metadata/parser/generic_parser.py
+++ b/sample_metadata/parser/generic_parser.py
@@ -1232,8 +1232,8 @@ class GenericParser(
                     if contents:
                         _checksum = f'md5:{contents.strip()}'
 
-            file_size = await self.file_size(filename)
-            datetime_added = await self.get_gcs_blob(file_location).time_created
+            file_size, file_blob = await asyncio.gather(self.file_size(filename), self.get_gcs_blob(file_location))
+            datetime_added = file_blob.time_created
 
         d = {
             'location': file_location,

--- a/test/test_parse_file_map.py
+++ b/test/test_parse_file_map.py
@@ -68,6 +68,7 @@ class TestSampleMapParser(unittest.TestCase):
                         'class': 'File',
                         'checksum': None,
                         'size': None,
+                        'datetime_added': None,
                     },
                     {
                         'location': 'gs://BUCKET/FAKE/<sample-id>.filename-R2.fastq.gz',
@@ -75,6 +76,7 @@ class TestSampleMapParser(unittest.TestCase):
                         'class': 'File',
                         'checksum': None,
                         'size': None,
+                        'datetime_added': None,
                     },
                 ]
             ],
@@ -145,6 +147,7 @@ class TestSampleMapParser(unittest.TestCase):
                 'class': 'File',
                 'checksum': '<checksum>',
                 'size': None,
+                'datetime_added': None,
             },
             {
                 'location': 'gs://BUCKET/FAKE/<sample-id>.filename-R2.fastq.gz',
@@ -152,6 +155,7 @@ class TestSampleMapParser(unittest.TestCase):
                 'class': 'File',
                 'checksum': '<checksum2>',
                 'size': None,
+                'datetime_added': None,
             },
         ]
 
@@ -166,6 +170,7 @@ class TestSampleMapParser(unittest.TestCase):
                 'class': 'File',
                 'checksum': '<checksum3>',
                 'size': None,
+                'datetime_added': None,
             },
             {
                 'location': 'gs://BUCKET/FAKE/<sample-id2>.filename-R2.fastq.gz',
@@ -173,6 +178,7 @@ class TestSampleMapParser(unittest.TestCase):
                 'class': 'File',
                 'checksum': '<checksum4>',
                 'size': None,
+                'datetime_added': None,
             },
         ]
         self.assertListEqual(

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -157,7 +157,6 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
-                    'datetime_added': None,
                 }
             ],
             'reads_type': 'bam',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -156,7 +156,26 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'basename': '<sample-id>.bam',
                     'class': 'File',
                     'checksum': None,
-                    'size': 111,
+                    'size': None,
+                    'datetime_added': None,
+                    'secondaryFiles': [
+                        {
+                            'location': '/path/to/<sample-id>.bam.bai',
+                            'basename': '<sample-id>.bam.bai',
+                            'class': 'File',
+                            'checksum': None,
+                            'size': None,
+                            'datetime_added': None,
+                        },
+                        {
+                            'location': '/path/to/<sample-id>.bai',
+                            'basename': '<sample-id>.bai',
+                            'class': 'File',
+                            'checksum': None,
+                            'size': None,
+                            'datetime_added': None,
+                        }
+                    ],
                 }
             ],
             'reads_type': 'bam',
@@ -166,13 +185,22 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'basename': '<sample-id>.g.vcf.gz',
                     'class': 'File',
                     'checksum': None,
-                    'size': 111,
+                    'size': None,
+                    'datetime_added': None,
+                    'secondaryFiles': [
+                        {
+                            'location': '/path/to/<sample-id>.g.vcf.gz.tbi',
+                            'basename': '<sample-id>.g.vcf.gz.tbi',
+                            'class': 'File',
+                            'checksum': None,
+                            'size': None,
+                            'datetime_added': None,
+                        }
+                    ],
                 }
             ],
             'gvcf_types': 'gvcf',
         }
-        for k,v in (sequences_to_add[0].meta).items():
-            print(k,v)
         self.assertDictEqual(expected_sequence_dict, sequences_to_add[0].meta)
         analysis = analyses_to_add['<sample-id>'][0]
         self.assertDictEqual(

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -119,6 +119,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             project='devdev',
             reads_column='CRAM',
             gvcf_column='GVCF',
+            skip_checking_gcs_objects=False,
         )
 
         parser.filename_map = {
@@ -445,6 +446,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             qc_meta_map={},
             # doesn't matter, we're going to mock the call anyway
             project='devdev',
+            skip_checking_gcs_objects=False,
         )
 
         parser.filename_map = {'file.cram': 'gs://path/file.cram'}

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -119,7 +119,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             project='devdev',
             reads_column='CRAM',
             gvcf_column='GVCF',
-            skip_checking_gcs_objects=False,
+            skip_checking_gcs_objects=True,
         )
 
         parser.filename_map = {
@@ -446,7 +446,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             qc_meta_map={},
             # doesn't matter, we're going to mock the call anyway
             project='devdev',
-            skip_checking_gcs_objects=False,
+            skip_checking_gcs_objects=True,
         )
 
         parser.filename_map = {'file.cram': 'gs://path/file.cram'}

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -525,6 +525,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': None,
+                    'datetime_added': None,
                 }
             ],
         }
@@ -600,6 +601,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': None,
+                    'datetime_added': None,
                 }
             ],
         }

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -266,6 +266,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                         'class': 'File',
                         'location': '/path/to/sample_id001.filename-R1.fastq.gz',
                         'size': None,
+                        'datetime_added': None,
                     },
                     {
                         'basename': 'sample_id001.filename-R2.fastq.gz',
@@ -273,6 +274,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                         'class': 'File',
                         'location': '/path/to/sample_id001.filename-R2.fastq.gz',
                         'size': None,
+                        'datetime_added': None,
                     },
                 ]
             ],
@@ -515,6 +517,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             'class': 'File',
             'checksum': None,
             'size': None,
+            'datetime_added': None,
             'secondaryFiles': [
                 {
                     'location': 'gs://path/file.fasta.fai',
@@ -589,6 +592,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             'class': 'File',
             'checksum': None,
             'size': None,
+            'datetime_added': None,
             'secondaryFiles': [
                 {
                     'location': 'gs://path/ref.fa.fai',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -168,7 +168,6 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
-                    'datetime_added': None,
                 }
             ],
             'gvcf_types': 'gvcf',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime
 from io import StringIO
 from unittest.mock import patch
 from test.testbase import run_as_sync
@@ -99,7 +100,7 @@ class TestParseGenericMetadata(unittest.TestCase):
 
         mock_filesize.return_value = 111
         mock_fileexists.return_value = False
-        mock_datetime_added.return_value = None
+        mock_datetime_added.return_value = datetime.fromisoformat('2022-02-02T22:22:22')
 
         rows = [
             'GVCF\tCRAM\tSampleId\tsample.flowcell_lane\tsample.platform\tsample.centre\tsample.reference_genome\traw_data.FREEMIX\traw_data.PCT_CHIMERAS\traw_data.MEDIAN_INSERT_SIZE\traw_data.MEDIAN_COVERAGE',
@@ -126,7 +127,6 @@ class TestParseGenericMetadata(unittest.TestCase):
             project='devdev',
             reads_column='CRAM',
             gvcf_column='GVCF',
-            # skip_checking_gcs_objects=True,
         )
 
         parser.filename_map = {
@@ -164,25 +164,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
-                    'datetime_added': None,
-                    # 'secondaryFiles': [
-                    #     {
-                    #         'location': '/path/to/<sample-id>.bam.bai',
-                    #         'basename': '<sample-id>.bam.bai',
-                    #         'class': 'File',
-                    #         'checksum': None,
-                    #         'size': None,
-                    #         'datetime_added': None,
-                    #     },
-                    #     {
-                    #         'location': '/path/to/<sample-id>.bai',
-                    #         'basename': '<sample-id>.bai',
-                    #         'class': 'File',
-                    #         'checksum': None,
-                    #         'size': None,
-                    #         'datetime_added': None,
-                    #     },
-                    # ],
+                    'datetime_added': '2022-02-02T22:22:22',
                 }
             ],
             'reads_type': 'bam',
@@ -193,17 +175,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
-                    'datetime_added': None,
-                    # 'secondaryFiles': [
-                    #     {
-                    #         'location': '/path/to/<sample-id>.g.vcf.gz.tbi',
-                    #         'basename': '<sample-id>.g.vcf.gz.tbi',
-                    #         'class': 'File',
-                    #         'checksum': None,
-                    #         'size': None,
-                    #         'datetime_added': None,
-                    #     }
-                    # ],
+                    'datetime_added': '2022-02-02T22:22:22',
                 }
             ],
             'gvcf_types': 'gvcf',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -156,6 +156,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
+                    'datetime_added': None,
                 }
             ],
             'reads_type': 'bam',
@@ -166,6 +167,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'class': 'File',
                     'checksum': None,
                     'size': 111,
+                    'datetime_added': None,
                 }
             ],
             'gvcf_types': 'gvcf',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -79,10 +79,16 @@ class TestParseGenericMetadata(unittest.TestCase):
     @run_as_sync
     @patch('sample_metadata.apis.SampleApi.get_sample_id_map_by_external')
     @patch('sample_metadata.apis.SequenceApi.get_sequence_ids_for_sample_ids_by_type')
+    @patch('sample_metadata.parser.cloudhelper.CloudHelper.datetime_added')
     @patch('sample_metadata.parser.cloudhelper.CloudHelper.file_exists')
     @patch('sample_metadata.parser.cloudhelper.CloudHelper.file_size')
     async def test_single_row(
-        self, mock_filesize, mock_fileexists, mock_get_sequence_ids, mock_get_sample_id
+        self,
+        mock_filesize,
+        mock_fileexists,
+        mock_datetime_added,
+        mock_get_sequence_ids,
+        mock_get_sample_id,
     ):
         """
         Test importing a single row, forms objects and checks response
@@ -93,6 +99,7 @@ class TestParseGenericMetadata(unittest.TestCase):
 
         mock_filesize.return_value = 111
         mock_fileexists.return_value = False
+        mock_datetime_added.return_value = None
 
         rows = [
             'GVCF\tCRAM\tSampleId\tsample.flowcell_lane\tsample.platform\tsample.centre\tsample.reference_genome\traw_data.FREEMIX\traw_data.PCT_CHIMERAS\traw_data.MEDIAN_INSERT_SIZE\traw_data.MEDIAN_COVERAGE',
@@ -119,7 +126,7 @@ class TestParseGenericMetadata(unittest.TestCase):
             project='devdev',
             reads_column='CRAM',
             gvcf_column='GVCF',
-            skip_checking_gcs_objects=True,
+            # skip_checking_gcs_objects=True,
         )
 
         parser.filename_map = {
@@ -156,26 +163,26 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'basename': '<sample-id>.bam',
                     'class': 'File',
                     'checksum': None,
-                    'size': None,
+                    'size': 111,
                     'datetime_added': None,
-                    'secondaryFiles': [
-                        {
-                            'location': '/path/to/<sample-id>.bam.bai',
-                            'basename': '<sample-id>.bam.bai',
-                            'class': 'File',
-                            'checksum': None,
-                            'size': None,
-                            'datetime_added': None,
-                        },
-                        {
-                            'location': '/path/to/<sample-id>.bai',
-                            'basename': '<sample-id>.bai',
-                            'class': 'File',
-                            'checksum': None,
-                            'size': None,
-                            'datetime_added': None,
-                        },
-                    ],
+                    # 'secondaryFiles': [
+                    #     {
+                    #         'location': '/path/to/<sample-id>.bam.bai',
+                    #         'basename': '<sample-id>.bam.bai',
+                    #         'class': 'File',
+                    #         'checksum': None,
+                    #         'size': None,
+                    #         'datetime_added': None,
+                    #     },
+                    #     {
+                    #         'location': '/path/to/<sample-id>.bai',
+                    #         'basename': '<sample-id>.bai',
+                    #         'class': 'File',
+                    #         'checksum': None,
+                    #         'size': None,
+                    #         'datetime_added': None,
+                    #     },
+                    # ],
                 }
             ],
             'reads_type': 'bam',
@@ -185,18 +192,18 @@ class TestParseGenericMetadata(unittest.TestCase):
                     'basename': '<sample-id>.g.vcf.gz',
                     'class': 'File',
                     'checksum': None,
-                    'size': None,
+                    'size': 111,
                     'datetime_added': None,
-                    'secondaryFiles': [
-                        {
-                            'location': '/path/to/<sample-id>.g.vcf.gz.tbi',
-                            'basename': '<sample-id>.g.vcf.gz.tbi',
-                            'class': 'File',
-                            'checksum': None,
-                            'size': None,
-                            'datetime_added': None,
-                        }
-                    ],
+                    # 'secondaryFiles': [
+                    #     {
+                    #         'location': '/path/to/<sample-id>.g.vcf.gz.tbi',
+                    #         'basename': '<sample-id>.g.vcf.gz.tbi',
+                    #         'class': 'File',
+                    #         'checksum': None,
+                    #         'size': None,
+                    #         'datetime_added': None,
+                    #     }
+                    # ],
                 }
             ],
             'gvcf_types': 'gvcf',

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -171,6 +171,8 @@ class TestParseGenericMetadata(unittest.TestCase):
             ],
             'gvcf_types': 'gvcf',
         }
+        for k,v in (sequences_to_add[0].meta).items():
+            print(k,v)
         self.assertDictEqual(expected_sequence_dict, sequences_to_add[0].meta)
         analysis = analyses_to_add['<sample-id>'][0]
         self.assertDictEqual(

--- a/test/test_parse_generic_metadata.py
+++ b/test/test_parse_generic_metadata.py
@@ -174,7 +174,7 @@ class TestParseGenericMetadata(unittest.TestCase):
                             'checksum': None,
                             'size': None,
                             'datetime_added': None,
-                        }
+                        },
                     ],
                 }
             ],

--- a/test/test_parse_ont_sheet.py
+++ b/test/test_parse_ont_sheet.py
@@ -81,6 +81,7 @@ class TestOntSampleSheetParser(unittest.TestCase):
                         'class': 'File',
                         'checksum': None,
                         'size': None,
+                        'datetime_added': None,
                     }
                 ]
             ],
@@ -96,6 +97,7 @@ class TestOntSampleSheetParser(unittest.TestCase):
                         'class': 'File',
                         'location': 'gs://BUCKET/FAKE/Sample01_pass.fastq.gz',
                         'size': None,
+                        'datetime_added': None,
                     }
                 ]
             ],


### PR DESCRIPTION
So these changes are kinda simple but at the same time I'm finding it difficult to test due to how baked into the API this section is with all the awaits/coroutine happenings.

What I think this is doing:
1. Define `datetime_added` as `None` to handle the case when the `skip_checking_gcs_objects` is `True`
2. Asynchronously pass the `file_location` into `get_gcs_blob` to get the blob object
3. Define `datetime_added` as the [blob attribute](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_time_created) `time_created` and add this to the meta dict
4. Blob's your uncle

**Unit tests**
I've changed the parser to initialise with the `skip_checking_gcs_objects=True` argument for `test_single_row` and `test_cram_with_no_reference`. These tests were getting stuck at the `get_gcs_blob` which returned a `ValueError` when the fake/test data was passed to it.

**Possible unit test issue**
Since `test_single_row` ends up calling `create_secondary_file_objects_by_potential_pattern` with `skip_checking_gcs_objects=True`, secondary file objects are created for this test. So, I've modified the test to include these secondary files in the expected output. 
Only thing is, this has broken the `mock_filesize=111` part of the test, so I changed the expected filesize to None. Not sure if this is desirable or something that I should go back and try to fix.