### PR TITLE
Bug fix

### DIFF
--- a/db/python/utils.py
+++ b/db/python/utils.py
@@ -262,7 +262,7 @@ class GenericFilterModel:
         if not conditionals:
             return 'True', {}
 
-        return ' AND '.join(conditionals), values
+        return ' AND '.join(filter(None, conditionals)), values
 
 
 def get_logger():


### PR DESCRIPTION
`conditionals` can sometimes have empty values which results in query strings that look like `AND AND`  