### PR TITLE
Limit test discover to test directory

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: "Run unit tests"
         id: runtests
         run: |
-          coverage run -m unittest discover
+          coverage run -m unittest discover -s test/
           rc=$?
           coverage xml
 


### PR DESCRIPTION
To stop the test discovery failing for lack of pulumi in requirements (which I don't really want to add).