### PR TITLE
Add mode as a column in Analysis Grid

### DIFF
--- a/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerGrid.tsx
+++ b/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerGrid.tsx
@@ -30,6 +30,7 @@ const MAIN_FIELDS = [
     { category: 'accessLevel', title: 'Access Level' },
     { category: 'Image', title: 'Driver Image' },
     { category: 'description', title: 'Description' },
+    { category: 'mode', title: 'Mode' },
 ]
 
 const AnalysisRunnerGrid: React.FunctionComponent<{
@@ -228,6 +229,7 @@ const AnalysisRunnerGrid: React.FunctionComponent<{
                                             </SUITable.Cell>
                                         )
                                     case 'Image':
+                                    case 'mode':
                                         return (
                                             <SUITable.Cell
                                                 key={category}
@@ -236,6 +238,7 @@ const AnalysisRunnerGrid: React.FunctionComponent<{
                                                 {_.get(log, category)}
                                             </SUITable.Cell>
                                         )
+
                                     case 'script':
                                         return (
                                             <SUITable.Cell key={category} className="scriptField">

--- a/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
+++ b/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
@@ -80,13 +80,17 @@ const AnalysisRunnerSummary: React.FunctionComponent = () => {
         ])
     }
 
+    // console.table(data?.project.analyses)
+
     const flatData = data?.project.analyses.map(({ author, id, output, meta }, i) => ({
         email: author,
         id,
         output,
         ...meta,
         position: i,
-        'Hail Batch': meta?.batch_url.replace('https://batch.hail.populationgenomics.org.au/', ''),
+        'Hail Batch': meta?.batch_url
+            ? meta?.batch_url.replace('https://batch.hail.populationgenomics.org.au/', '')
+            : '',
         GitHub: `${meta?.repo}@${meta?.commit.substring(0, 7)}`,
         Date: `${parseDate(sanitiseValue(meta?.timestamp))}`,
         Author: `${parseEmail(sanitiseValue(author))}`,

--- a/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
+++ b/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
@@ -80,8 +80,6 @@ const AnalysisRunnerSummary: React.FunctionComponent = () => {
         ])
     }
 
-    // console.table(data?.project.analyses)
-
     const flatData = data?.project.analyses.map(({ author, id, output, meta }, i) => ({
         email: author,
         id,


### PR DESCRIPTION
This change allows you to search explicitly for cromwell (or other modes) in the Analysis Grid UI.
Also fixes a bug where missing hail batch URLs caused errors
![Screenshot 2023-06-13 at 1 41 21 pm](https://github.com/populationgenomics/sample-metadata/assets/47542969/9a7ac9d2-14ec-4818-9916-c2de1b3b3841)
