### PR TITLE
Add internal pid to ParticipantUpsert constructor

### DIFF
--- a/metamist/parser/generic_parser.py
+++ b/metamist/parser/generic_parser.py
@@ -216,6 +216,7 @@ class ParsedParticipant:
         """Convert to SM upsert model"""
         samples = [s.to_sm() for s in self.samples]
         return ParticipantUpsert(
+            id=self.internal_pid,
             external_id=self.external_pid,
             reported_sex=self.reported_sex,
             reported_gender=self.reported_gender,


### PR DESCRIPTION
Adding in the internal participant ID to align with the other Upsert constructors. 

Without the internal ID field, the ParticipantUpsert objects can't be distinguished by the parser when it decides which participants should be created vs which should be updated.

In theory, this should have been caught by [`test_matching_sequencing_groups_and_assays`](https://github.com/populationgenomics/sample-metadata/blob/e94a9e757c4d4efff13a68302fee6eb230ac7fef/test/test_parse_generic_metadata.py#L742) from `test_parse_generic_metadata.py`, however with the `dry-run` flag present in the [`parse_manifest` call](https://github.com/populationgenomics/sample-metadata/blob/e94a9e757c4d4efff13a68302fee6eb230ac7fef/test/test_parse_generic_metadata.py#L781), `participant.to_sm()` is never triggered so the test didn't find this bug. 
