### PR TITLE
Add blob.reload() call to cloudhelper get_gcs_blob

### DIFF
--- a/metamist/parser/cloudhelper.py
+++ b/metamist/parser/cloudhelper.py
@@ -190,6 +190,10 @@ class CloudHelper:
             # maintain existing behaviour
             return None
 
+        if not blob.time_created:
+            # GCP blobs sometimes need a reload
+            blob.reload()
+
         return blob
 
     def _list_gcs_directory(self, gcs_path) -> list[str]:


### PR DESCRIPTION
This one is a bit odd, I noticed that newly ingested `assay` entries were always ending up with `datetime_added: null` in their metadata. 

Doing some digging, the CloudHelper is trying to get the gcs blob create time with the blob.time_created attribute, which should work, however it has been returning `None` for everything lately.

I've found that a [reload](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_reload) call refreshes the blob attributes and allows the create time to be accessed. Not sure if this is the best way to implement this or if I should add the `reload` call specifically into the `datetime_added` function.

```
>>> print(blob.time_created)
None
>>> blob.reload()
>>> print(blob.time_created)
2023-05-01 05:30:39.315000+00:00
```