### PR TITLE
Audit module and test update for SG changes

### DIFF
--- a/metamist/audit/audit_upload_bucket.py
+++ b/metamist/audit/audit_upload_bucket.py
@@ -5,14 +5,14 @@ as well as samples that have no completed cram.
 
 Procedure:
 1. Input a Metamist dataset, sequence types to audit, and file types to search for in the bucket
-2. Get all the participants, samples, and sequences for this dataset from Metamist
-3. Search the upload bucket for all sequence files, and compare to the files in the metamist sequences
+2. Get all the participants, samples, sequencing groups, and assays for this dataset
+3. Search the upload bucket for all assay files, and compare to the files in the metamist assay reads
     - If there are discrepencies, check if the file name and size is the same in the bucket as it is in metamist
       - If the name and file size are the same, assume this file has just been moved around in the bucket
-4. Check if a sample has a completed cram - if so, its sequence data can be removed
-5. Any remaining sequence data in the bucket might require ingestion
-6. Create reports in the audit_results folder of the upload bucket, containing sequence files to delete,
-   ingest, and any samples without completed crams.
+4. Check if a sequencing group has a completed cram - if so, its assay read files can be removed
+5. Any remaining assay data in the bucket might require ingestion
+6. Create reports in the audit_results folder of the upload bucket, containing assay read files to delete,
+   ingest, and any sequencing groups without completed crams.
 """
 
 
@@ -51,7 +51,7 @@ FILE_TYPES_MAP = {
     'all': ALL_EXTENSIONS,
 }
 
-SEQUENCE_TYPES_MAP = {
+SEQUENCING_TYPES_MAP = {
     'genome': [
         'genome',
     ],
@@ -89,59 +89,66 @@ class UploadBucketAuditor(GenericAuditor):
         bucket_name: str,
         sequencing_type_str: str,
         file_types_str: str,
-        sequence_files_to_delete: list[tuple[str, int, str, list[int]]],
-        sequence_files_to_ingest: list[tuple[str, str, str, int, str]],
-        incomplete_samples: list[tuple[str, str]],
+        assay_files_to_delete: list[tuple[str, int, str, list[int]]],
+        assay_files_to_ingest: list[tuple[str, str, str, int, str]],
+        unaligned_sgs: list[tuple[str, str]],
     ):
-        """Write the sequences to delete and ingest to csv files and upload them to the bucket"""
-        # Writing the output to files with the file type, sequence type, and date specified
+        """
+        Writes the 'sequence files to delete/ingest' csv reports and upload them to the bucket.
+        Also writes a report for any sequence files found that match existing samples and may
+        require ingestion.
+
+        The reports name includes the file types, sequencing types, and date of the audit.
+        """
         today = datetime.today().strftime('%Y-%m-%d')
 
         report_path = f'{bucket_name}/audit_results/{today}/'
 
-        # Sequences to delete report has several data points for validation
-        if not sequence_files_to_delete:
-            logging.info('No sequence read files to delete found. Skipping report...')
+        if not assay_files_to_delete:
+            logging.info('No assay read files to delete found. Skipping report...')
         else:
-            sequences_to_delete_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_sequences_to_delete_{today}.csv'
+            assays_to_delete_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_assay_files_to_delete_{today}.csv'
             self.write_csv_report_to_cloud(
-                data_to_write=sequence_files_to_delete,
-                report_path=os.path.join(report_path, sequences_to_delete_file),
+                data_to_write=assay_files_to_delete,
+                report_path=os.path.join(report_path, assays_to_delete_file),
                 header_row=[
-                    'Sample_ID',
-                    'Sequence_ID',
-                    'Sequence_Path',
+                    'SG_ID',
+                    'Assay_ID',
+                    'Assay_Read_File_Path',
                     'Analysis_IDs',
                     'Filesize',
                 ],
             )
 
-        # Sequences to ingest file only contains paths to the (possibly) uningested files
-        if not sequence_files_to_ingest:
-            logging.info('No sequence reads to ingest found. Skipping report...')
+        # 'Sequences to ingest' report contains paths to the (possibly) uningested files - and any samples/SGs that might be related
+        if not assay_files_to_ingest:
+            logging.info('No assay reads to ingest found. Skipping report...')
         else:
-            sequences_to_ingest_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_sequences_to_ingest_{today}.csv'
+            assays_to_ingest_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_assay_files_to_ingest_{today}.csv'
             self.write_csv_report_to_cloud(
-                data_to_write=sequence_files_to_ingest,
-                report_path=os.path.join(report_path, sequences_to_ingest_file),
+                data_to_write=assay_files_to_ingest,
+                report_path=os.path.join(report_path, assays_to_ingest_file),
                 header_row=[
-                    'Sequence_Path',
-                    'Extenal_Sample_ID',
-                    'Internal_Sample_ID',
+                    'Assay_File_Path',
+                    'SG_ID',
+                    'Sample_ID',
+                    'Sample_External_ID',
                     'CRAM_Analysis_ID',
                     'CRAM_Path',
                 ],
             )
 
-        # Write the samples without any completed cram to a csv
-        if not incomplete_samples:
-            logging.info(f'No samples without crams found. Skipping report...')
+        # Write the sequencing groups without any completed cram to a csv
+        if not unaligned_sgs:
+            logging.info(
+                f'No sequencing groups without crams found. Skipping report...'
+            )
         else:
-            incomplete_samples_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_samples_without_crams_{today}.csv'
+            unaligned_sgs_file = f'{self.dataset}_{file_types_str}_{sequencing_type_str}_unaligned_sgs_{today}.csv'
             self.write_csv_report_to_cloud(
-                data_to_write=incomplete_samples,
-                report_path=os.path.join(report_path, incomplete_samples_file),
-                header_row=['Internal_Sample_ID', 'External_Sample_ID'],
+                data_to_write=unaligned_sgs,
+                report_path=os.path.join(report_path, unaligned_sgs_file),
+                header_row=['SG_ID', 'Sample_ID', 'Sample_External_ID'],
             )
 
 
@@ -158,10 +165,11 @@ async def audit_upload_bucket_files(
         dataset = config['workflow']['dataset']
 
     bucket_name = config['storage']['default']['upload']
+    bucket_name = f'gs://cpg-{dataset}-main-upload'
 
     auditor = UploadBucketAuditor(
         dataset=dataset,
-        sequencing_type=SEQUENCE_TYPES_MAP.get(sequencing_type),
+        sequencing_type=SEQUENCING_TYPES_MAP.get(sequencing_type),
         file_types=FILE_TYPES_MAP.get(file_types),
         default_analysis_type=default_analysis_type,
         default_analysis_status=default_analysis_status,
@@ -177,57 +185,62 @@ async def audit_upload_bucket_files(
 
     # Get all the sequences for the samples in the dataset and map them to their samples and reads
     (
-        seq_id_sample_id_map,
-        sequence_filepaths_filesizes,
-    ) = auditor.get_sequence_map_from_participants(participant_data)
+        sg_sample_id_map,
+        assay_sg_id_map,
+        assay_filepaths_filesizes,
+    ) = auditor.get_assay_map_from_participants(participant_data)
 
     # Get all completed cram output paths for the samples in the dataset and validate them
-    sample_cram_paths = auditor.get_analysis_cram_paths_for_dataset_samples(
-        sample_internal_external_id_map
-    )
+    sg_cram_paths = auditor.get_analysis_cram_paths_for_dataset_sgs(assay_sg_id_map)
 
-    # Identify samples with and without completed crams
-    sample_completion = auditor.get_complete_and_incomplete_samples(
-        sample_internal_external_id_map, sample_cram_paths
+    # Identify sgs with and without completed crams
+    sg_completion = auditor.get_complete_and_incomplete_sgs(
+        assay_sg_id_map, sg_cram_paths
     )
-    incomplete_samples = [
-        (sample_id, sample_internal_external_id_map.get(sample_id))
-        for sample_id in sample_completion.get('incomplete')
+    unaligned_sgs = [
+        (
+            sg_id,
+            sg_sample_id_map[sg_id],
+            sample_internal_external_id_map.get(sg_sample_id_map[sg_id]),
+        )
+        for sg_id in sg_completion.get('incomplete')
     ]
 
     # Samples with completed crams can have their sequences deleted - these are the obvious ones
     (
-        sequence_reads_to_delete,
-        sequence_files_to_ingest,
+        reads_to_delete,
+        reads_to_ingest,
     ) = await auditor.get_reads_to_delete_or_ingest(
         bucket_name,
-        sample_completion.get('complete'),
-        sequence_filepaths_filesizes,
-        seq_id_sample_id_map,
+        sg_completion.get('complete'),
+        assay_filepaths_filesizes,
+        sg_sample_id_map,
+        assay_sg_id_map,
         sample_internal_external_id_map,
     )
 
-    possible_sequence_ingests = auditor.find_crams_for_reads_to_ingest(
-        sequence_files_to_ingest, sample_cram_paths
+    possible_assay_ingests = auditor.find_crams_for_reads_to_ingest(
+        reads_to_ingest, sg_cram_paths
     )
 
     auditor.write_upload_bucket_audit_reports(
         bucket_name,
         sequencing_type_str=sequencing_type,
         file_types_str=file_types,
-        sequence_files_to_delete=sequence_reads_to_delete,
-        sequence_files_to_ingest=possible_sequence_ingests,
-        incomplete_samples=incomplete_samples,
+        assay_files_to_delete=reads_to_delete,
+        assay_files_to_ingest=possible_assay_ingests,
+        unaligned_sgs=unaligned_sgs,
     )
 
 
 @click.command()
 @click.option(
     '--dataset',
+    '-d',
     help='Metamist dataset, used to filter samples',
 )
 @click.option(
-    '--sequence-type',
+    '--sequencing-type',
     '-s',
     type=click.Choice(['genome', 'exome', 'all']),
     required='True',

--- a/metamist/audit/audithelper.py
+++ b/metamist/audit/audithelper.py
@@ -12,41 +12,6 @@ from metamist.parser.cloudhelper import CloudHelper
 class AuditHelper(CloudHelper):
     """General helper class for bucket auditing"""
 
-    RD_DATASETS = [
-        'acute-care',
-        'ag-cardiac',
-        'ag-hidden',
-        'ag-very-hidden',
-        'brain-malf',
-        'broad-rgp',
-        'circa',
-        'epileptic-enceph',
-        'flinders-ophthal',
-        'genomic-autopsy',
-        'heartkids',
-        'hereditary-neuro',
-        'ibmdx',
-        'kidgen',
-        'leukodystrophies',
-        'lof-curation',
-        'mcri-lrp',
-        'mito-disease',
-        'mito-mdt',
-        'ohmr3-mendelian',
-        'ohmr4-epilepsy',
-        'perth-neuro',
-        'rare-disease',
-        'ravenscroft-arch',
-        'ravenscroft-rdstudy',
-        'rdnow',
-        'rdp-kidney',
-        'rdp-neuro',
-        'schr-neuro',
-        'seqr',
-        'udn-aus',
-        'validation',
-    ]
-
     EXCLUDED_SGS = [
         'CPG11783',  # acute-care, no FASTQ data
         'CPG13409',  # perth-neuro, coverage ~0x

--- a/metamist/audit/delete_assay_files_from_audit.py
+++ b/metamist/audit/delete_assay_files_from_audit.py
@@ -7,9 +7,9 @@ of the csv contains the paths to delete.
 Creates a log file of all the deletes, in the same directory as the input csv.
 
 The typical upload-bucket audit results will be found in a file such as:
- > gs://cpg-dataset-main-upload/audit_results/2023-xx-xx/dataset_seqtype_readstype_sequences_to_delete_2023-xx-xx.csv
+ > gs://cpg-dataset-main-upload/audit_results/2023-xx-xx/dataset_seqtype_readstype_assay_files_to_delete_20xx-xx-xx.csv
 And the field name containing the delete paths will be
- > "Sequence_Path"
+ > "Assay_Read_File_Path"
 """
 
 import csv
@@ -44,7 +44,7 @@ def clean_up_cloud_storage(locations: list[CloudPath]):
     return deleted_files
 
 
-@click.command('Delete the sequence paths found by the audit')
+@click.command('Delete the assay files found by the audit')
 @click.option(
     '--delete-field-name',
     '-d',
@@ -80,7 +80,6 @@ def main(delete_field_name, delete_file_path):
     AuditHelper.write_csv_report_to_cloud(
         deleted_files, log_path, header_row=['Deleted_file_path']
     )
-    logging.info(f'Wrote deletion log to {log_path}.')
 
 
 if __name__ == '__main__':

--- a/metamist/audit/generic_auditor.py
+++ b/metamist/audit/generic_auditor.py
@@ -462,7 +462,7 @@ class GenericAuditor(AuditHelper):
         # Check the list of uningested paths to see if any of them contain sample ids for ingested samples
         # This could happen when we ingest a fastq read pair for a sample, and additional read files were provided
         # but not ingested, such as bams and vcfs.
-        uningested_reads: dict[str, list[tuple[str, str]]] = defaultdict(
+        uningested_reads: dict[str, list[tuple[str, str, str]]] = defaultdict(
             list, {k: [] for k in uningested_assay_paths}
         )
         for sg_id, analysis_ids in completed_sgs.items():
@@ -572,7 +572,7 @@ class GenericAuditor(AuditHelper):
     def find_crams_for_reads_to_ingest(
         reads_to_ingest: dict[str, list],
         sg_cram_paths: dict[str, dict[int, str]],
-    ) -> list[tuple[str, str, str, int, str]]:
+    ) -> list[tuple[str, str, str, str, int, str]]:
         """
         Compares the external sample IDs for samples with completed CRAMs against the
         uningested read files. This may turn up results for cases where multiple read types

--- a/metamist/audit/generic_auditor.py
+++ b/metamist/audit/generic_auditor.py
@@ -3,43 +3,25 @@ import logging
 import os
 from typing import Any
 
+from gql.transport.requests import log as requests_logger
 from metamist.audit.audithelper import AuditHelper
-from metamist.graphql import query
+from metamist.graphql import query, gql
 
 
 ANALYSIS_TYPES = [
     'QC',
-    'JOINT_CALLING',
+    'JOINT-CALLING',
     'GVCF',
     'CRAM',
     'CUSTOM',
-    'ES_INDEX',
+    'ES-INDEX',
     'SV',
-    'WEB_REPORT',
-    'ANALYSIS_RUNNER',
+    'WEB',
+    'ANALYSIS-RUNNER',
 ]
 
-EXCLUDED_SAMPLES = [
-    'CPG11783',  # acute-care, no FASTQ data
-    'CPG13409',  # perth-neuro, coverage ~0x
-    'CPG243717',  # validation, NA12878_KCCG low coverage https://main-web.populationgenomics.org.au/validation/qc/cram/multiqc.html,
-    'CPG246645',  # ag-hidden, eof issue  https://batch.hail.populationgenomics.org.au/batches/97645/jobs/440
-    'CPG246678',  # ag-hidden, diff fastq size  https://batch.hail.populationgenomics.org.au/batches/97645/jobs/446
-    'CPG261792',  # rdp-kidney misformated fastq - https://batch.hail.populationgenomics.org.au/batches/378736/jobs/43
-    # acute care fasq parsing errors https://batch.hail.populationgenomics.org.au/batches/379303/jobs/24
-    'CPG259150',
-    'CPG258814',
-    'CPG258137',
-    'CPG258111',
-    'CPG258012',
-    # ohmr4 cram parsing in align issues
-    'CPG261339',
-    'CPG261347',
-    # IBMDX truncated sample? https://batch.hail.populationgenomics.org.au/batches/422181/jobs/99
-    'CPG265876',
-]
-
-PARTICIPANTS_SAMPLES_SEQUENCES_QUERY = """
+QUERY_PARTICIPANTS_SAMPLES_SGS_ASSAYS = gql(
+    """
         query DatasetData($datasetName: String!) {
             project(name: $datasetName) {
                 participants {
@@ -48,21 +30,26 @@ PARTICIPANTS_SAMPLES_SEQUENCES_QUERY = """
                     samples {
                         id
                         externalId
-                        sequences {
+                        sequencingGroups {
                             id
-                            meta
                             type
+                            assays {
+                                id
+                                meta
+                            }
                         }
                     }
                 }
             }
         }
         """
+)
 
-SAMPLE_ANALYSIS_QUERY = """
-        query sampleCrams($sampleId: String!, $analysisType: AnalysisType!) {
-          sample(id: $sampleId) {
-            analyses(status: COMPLETED, type: $analysisType) {
+QUERY_SG_ANALYSES = gql(
+    """
+        query sgAnalyses($sgId: String!, $analysisType: String!) {
+          sequencingGroups(id: {eq: $sgId}) {
+            analyses(status: {eq: COMPLETED}, type: {eq: $analysisType}) {
               id
               meta
               output
@@ -71,16 +58,17 @@ SAMPLE_ANALYSIS_QUERY = """
           }
         }
 """
+)
 
 # Variable type definitions
-SequenceId = int
+AssayId = int
 SampleId = str
 SampleExternalId = str
 ParticipantExternalId = str
 
-SequenceReportEntry = namedtuple(
-    'SequenceReportEntry',
-    'sample_id sequence_id sequence_file_path analysis_ids filesize',
+AssayReportEntry = namedtuple(
+    'AssayReportEntry',
+    'sg_id assay_id assay_file_path analysis_ids filesize',
 )
 
 
@@ -107,31 +95,32 @@ class GenericAuditor(AuditHelper):
         self.default_analysis_type: str = default_analysis_type
         self.default_analysis_status: str = default_analysis_status
 
+        requests_logger.setLevel(logging.WARNING)
+
     def get_participant_data_for_dataset(self) -> list[dict]:
         """
         Uses a graphQL query to return all participants in a Metamist dataset.
         Nested in the return are all samples associated with the participants,
-        and then all the sequences associated with those samples.
+        and then all the assays associated with those samples.
         """
 
-        participant_data = query(   # pylint: disable=unsubscriptable-object
-            PARTICIPANTS_SAMPLES_SEQUENCES_QUERY, {'datasetName': self.dataset}
+        participant_data = query(  # pylint: disable=unsubscriptable-object
+            QUERY_PARTICIPANTS_SAMPLES_SGS_ASSAYS, {'datasetName': self.dataset}
         )['project']['participants']
 
-        # Filter out any participants with no samples and log any found
+        filtered_participants = []
         for participant in participant_data:
-            if not participant.get('samples'):
+            if not participant['samples']:
                 logging.info(
-                    f'{self.dataset} :: Filtering participant {participant.get("id")} ({participant.get("externalId")}) it has no samples.'
+                    f'{self.dataset} :: Filtering participant {participant["id"]} ({participant["externalId"]}) as it has no samples.'
                 )
-        participant_data = [
-            participant
-            for participant in participant_data
-            if participant.get('samples')
-        ]
+                continue
+            filtered_participants.append(participant)
 
-        return participant_data
+        return filtered_participants
 
+    # TODO
+    # Remove this method?
     @staticmethod
     def map_participants_to_samples(
         participants: list[dict],
@@ -142,26 +131,25 @@ class GenericAuditor(AuditHelper):
         - Also reports if any participants have more than one sample
         """
 
-        # Create mapping of participant external ID to sample ID
+        # Create mapping of participant external id to sample id
         participant_eid_sample_id_map = {
-            participant.get('externalId'): [
-                sample.get('id') for sample in participant.get('samples')
+            participant['externalId']: [
+                sample['id'] for sample in participant['samples']
             ]
             for participant in participants
         }
 
-        # Create mapping of participant external ID to internal ID
+        # Create mapping of participant external id to internal id
         participant_eid_to_iid = {
-            participant.get('externalId'): participant.get('id')
-            for participant in participants
+            participant['externalId']: participant['id'] for participant in participants
         }
 
-        # Report if any participants have more than one sample ID
+        # Report if any participants have more than one sample id
         for participant_eid, sample_ids in participant_eid_sample_id_map.items():
             if len(sample_ids) > 1:
                 logging.info(
                     f'Participant {participant_eid_to_iid[participant_eid]} '
-                    f'(external ID: {participant_eid}) associated with more than '
+                    f'(external id: {participant_eid}) associated with more than '
                     f'one sample id: {sample_ids}'
                 )
 
@@ -172,235 +160,195 @@ class GenericAuditor(AuditHelper):
         participants: list[dict],
     ) -> dict[SampleId, SampleExternalId]:
         """
-        Returns the {internal sample ID : external sample ID} mapping for all
-            participants in a Metamist dataset
-        Also removes any samples that are part of the exclusions list
+        Returns the {internal sample id : external sample id} mapping for all participants in a Metamist dataset
         """
-        # Create a list of dictionaries, each mapping a sample ID to its external ID
-        samples_all = [
-            {
-                sample.get('id'): sample.get('externalId')
-                for sample in participant['samples']
-            }
+        return {
+            sample['id']: sample['externalId']
             for participant in participants
-        ]
-
-        # Squish them into a single dictionary not a list of dictionaries
-        sample_internal_external_id_map = {
-            sample_id: sample_external_id
-            for sample_map in samples_all
-            for sample_id, sample_external_id in sample_map.items()
-            if sample_id not in EXCLUDED_SAMPLES
+            for sample in participant['samples']
         }
 
-        return sample_internal_external_id_map
-
-    def get_sequence_map_from_participants(
+    def get_assay_map_from_participants(
         self, participants: list[dict]
-    ) -> tuple[dict[Any, Any], dict[Any, list[tuple[Any, Any]]]]:
+    ) -> tuple[dict[str, str], dict[int, str], dict[Any, list[tuple[Any, Any]]]]:
         """
-        Input the list of Metamist participant dictionaries from the master graphql Query
+        Input the list of Metamist participant dictionaries from the 'QUERY_PARTICIPANTS_SAMPLES_SGS_ASSAYS' query
 
-        Returns dictionary mappings:
-        {sequence_id : sample_internal_id}, and {sequence_id : (sequence_filepath, sequence_filesize)}
+        Returns the mappings:
+        1. { sg_id       : sample_id }
+        2. { assay_id       : sg_id }
+        3. { assay_id    : (read_filepath, read_filesize,) }
         """
-        all_sequences = [
-            {
-                sample.get('id'): sample.get('sequences')
-                for sample in participant.get('samples')
-            }
+
+        sg_sample_id_map = {}
+        assay_sg_id_map = {}
+        assay_filepaths_filesizes = defaultdict(list)
+
+        sample_sgs = {
+            sample['id']: sample['sequencingGroups']
             for participant in participants
-        ]
+            for sample in participant['samples']
+        }
+        for sample_id, sgs in sample_sgs.items():
+            for sg in sgs:
+                if not sg['type'].lower() in self.sequencing_type:
+                    continue
 
-        seq_id_sample_id_map = {}
-        # multiple reads per sequence is possible so use defaultdict(list)
-        sequence_filepaths_filesizes = defaultdict(list)
-        for sample_sequence in all_sequences:  # pylint: disable=R1702
-            sample_internal_id = list(sample_sequence.keys())[
-                0
-            ]  # Extract the sample ID
-            for sequences in sample_sequence.values():
-                for sequence in sequences:
-                    if not sequence.get('type').lower() in self.sequencing_type:
-                        continue
-                    meta = sequence.get('meta')
-                    reads = meta.get('reads')
-                    seq_id_sample_id_map[sequence.get('id')] = sample_internal_id
+                sg_sample_id_map[sg['id']] = sample_id
+                for assay in sg['assays']:
+                    reads = assay['meta'].get('reads')
                     if not reads:
-                        logging.info(
-                            f'Sample {sample_internal_id} has no sequence reads'
+                        logging.warning(
+                            f'{self.dataset} :: SG {sg["id"]} assay {assay["id"]} has no reads field'
                         )
                         continue
-                    # support up to three levels of nesting, because:
-                    #
-                    #   - reads is typically an array
-                    #       - handle the case where it's not an array
-                    #   - fastqs exist in pairs.
-                    # eg:
-                    #   - reads: cram   # this shouldn't happen, but handle it anyway
-                    #   - reads: [cram1, cram2]
-                    #   - reads: [[fq1_forward, fq1_back], [fq2_forward, fq2_back]]
-                    if isinstance(reads, dict):
-                        sequence_filepaths_filesizes[sequence.get('id')].append(
-                            (reads.get('location'), reads.get('size'))
-                        )
-                        continue
-                    if not isinstance(reads, list):
-                        logging.error(f'Invalid read type: {type(reads)}: {reads}')
-                        continue
+
+                    assay_sg_id_map[assay['id']] = sg['id']
                     for read in reads:
-                        if isinstance(read, list):
-                            for inner_read in read:
-                                if not isinstance(inner_read, dict):
-                                    logging.error(
-                                        f'Got {type(inner_read)} read, expected dict: {inner_read}'
-                                    )
-                                    continue
-                                sequence_filepaths_filesizes[sequence.get('id')].append(
-                                    (inner_read.get('location'), inner_read.get('size'))
-                                )
-                        else:
-                            if not isinstance(read, dict):
-                                logging.error(
-                                    f'Got {type(read)} read, expected dict: {read}'
-                                )
-                                continue
-                            sequence_filepaths_filesizes[sequence.get('id')].append(
-                                (read.get('location'), read.get('size'))
+                        if not isinstance(read, dict):
+                            logging.error(
+                                f'{self.dataset} :: Got {type(read)} read for SG {sg["id"]}, expected dict: {read}'
                             )
+                            continue
 
-        return seq_id_sample_id_map, sequence_filepaths_filesizes
+                        assay_filepaths_filesizes[assay['id']].append(
+                            (
+                                read.get('location'),
+                                read.get('size'),
+                            )
+                        )
 
-    def get_analysis_cram_paths_for_dataset_samples(
+        return sg_sample_id_map, assay_sg_id_map, assay_filepaths_filesizes
+
+    def get_analysis_cram_paths_for_dataset_sgs(
         self,
-        sample_internal_to_external_id_map: dict[str, str],
+        assay_sg_id_map: dict[int, str],
     ) -> dict[str, dict[int, str]]:
         """
-        Queries all analyses for the list of samples in the given dataset AND the seqr dataset.
-        Returns a dict mapping {sample_id : (analysis_id, cram_path) }
+        Fetches all CRAMs for the list of sgs in the given dataset AND the seqr dataset.
+        Returns a dict mapping {sg_id : (analysis_id, cram_path) }
         """
-        sample_ids = list(sample_internal_to_external_id_map.keys())
+        sg_ids = list(assay_sg_id_map.values())
 
         analyses = []
-        for sample in sample_ids:
+        for sg_id in sg_ids:
             analyses.extend(
-                query(   # pylint: disable=unsubscriptable-object
-                    SAMPLE_ANALYSIS_QUERY, {'sampleId': sample, 'analysisType': 'CRAM'}
-                )['sample']['analyses']
+                [
+                    sg['analyses']
+                    for sg in query(  # pylint: disable=unsubscriptable-object
+                        QUERY_SG_ANALYSES, {'sgId': sg_id, 'analysisType': 'CRAM'}
+                    )['sequencingGroups']
+                ]
             )
-        # Report any crams missing the sequence type
+        analyses = [
+            analysis for analyses_list in analyses for analysis in analyses_list
+        ]
+        # Report any crams missing the sequencing type
         crams_with_missing_seq_type = [
-            analysis.get('id')
+            analysis['id']
             for analysis in analyses
             if 'sequencing_type' not in analysis['meta']
         ]
         if crams_with_missing_seq_type:
             raise ValueError(
-                f'CRAMs from dataset {self.dataset} did not have sequencing_type: {crams_with_missing_seq_type}'
+                f'{self.dataset} :: CRAM analyses are missing sequencing_type field: {crams_with_missing_seq_type}'
             )
 
-        # Filter the analyses based on input sequence type
+        # Filter the analyses based on input sequencing type
         analyses = [
             analysis
             for analysis in analyses
-            if analysis.get('meta')['sequencing_type'] in self.sequencing_type
+            if analysis['meta'].get('sequencing_type') in self.sequencing_type
         ]
 
-        # For each sample ID, collect the analysis IDs and cram paths
-        sample_cram_paths: dict[str, dict[int, str]] = defaultdict(dict)
+        # For each sg id, collect the analysis ids and cram paths
+        sg_cram_paths: dict[str, dict[int, str]] = defaultdict(dict)
         for analysis in analyses:
             # Check the analysis output path is a valid gs path to a .cram file
             if not analysis['output'].startswith('gs://') and analysis[
                 'output'
             ].endswith('cram'):
-                logging.info(
+                logging.warning(
                     f'Analysis {analysis["id"]} invalid output path: {analysis["output"]}'
                 )
                 continue
+
             try:
-                # Try getting the sample ID from the 'sample_ids' field
-                sample_id = analysis['sample_ids'][0]
-            except KeyError:
-                # Try getting the sample ID from the 'sample' meta field
-                sample_id = analysis.get('meta')['sample']
-                logging.warning(
-                    f'Analysis: {analysis.get("id")} missing "sample_ids" field. Using analysis["meta"].get("sample") instead.'
+                sg_id = self.get_sequencing_group_ids_from_analysis(analysis)[0]
+                sg_cram_paths[sg_id].update(
+                    [(analysis.get('id'), analysis.get('output'))]
                 )
+            except ValueError:
+                logging.warning(
+                    f'Analysis {analysis["id"]} missing sample or sequencing group field.'
+                )
+                continue
 
-            sample_cram_paths[sample_id].update(
-                [(analysis.get('id'), analysis.get('output'))]
-            )
+        return sg_cram_paths
 
-        return sample_cram_paths
-
-    def analyses_for_samples_without_crams(self, samples_without_crams: list[str]):
+    def analyses_for_sgs_without_crams(self, sgs_without_crams: list[str]):
         """Checks if other completed analyses exist for samples without completed crams"""
 
-        all_sample_analyses: dict[str, list[dict[str, int | str]]] = defaultdict(
-            list
-        )
+        all_sg_analyses: dict[str, list[dict[str, int | str]]] = defaultdict(list)
 
         analyses = []
         for analysis_type in ANALYSIS_TYPES:
             if analysis_type == 'CRAM':
                 continue
-            for sample in samples_without_crams:
+            for sg in sgs_without_crams:
                 analyses.extend(
-                    query(  # pylint: disable=unsubscriptable-object
-                        SAMPLE_ANALYSIS_QUERY,
-                        {'sampleId': sample, 'analysisType': analysis_type},
-                    )['sample']['analyses']
+                    [
+                        sg['analyses']
+                        for sg in query(  # pylint: disable=unsubscriptable-object
+                            QUERY_SG_ANALYSES,
+                            {'sgId': sg, 'analysisType': analysis_type},
+                        )['sequencingGroups']
+                    ]
                 )
-
+        analyses = [
+            analysis for analyses_list in analyses for analysis in analyses_list
+        ]
         for analysis in analyses:
             try:
-                # Try getting the sample IDs from the 'sample_ids' field
-                samples = analysis['sample_ids']
-            except KeyError:
-                # Try getting the sample IDs from the 'sample' meta field
-                try:
-                    samples = analysis['meta']['sample']
-                # Try getting the sample ID from the 'samples' meta field
-                except KeyError:
-                    samples = analysis['meta']['samples']
+                sg_ids = self.get_sequencing_group_ids_from_analysis(analysis)
+            except ValueError:
+                logging.warning(
+                    f'Analysis {analysis["id"]} missing sample or sequencing group field.'
+                )
+                continue
 
-            if not isinstance(samples, list):
-                samples = [
-                    samples,
-                ]
-
-            for sample_id in samples:
-                if sample_id not in samples_without_crams:
+            for sg_id in sg_ids:
+                if sg_id not in sgs_without_crams:
                     continue
                 analysis_entry = {
-                    'analysis_id': analysis.get('id'),
-                    'analysis_type': analysis.get('type'),
-                    'analysis_output': analysis.get('output'),
-                    'timestamp_completed': analysis.get('timestampCompleted'),
+                    'analysis_id': analysis['id'],
+                    'analysis_type': analysis['type'],
+                    'analysis_output': analysis['output'],
+                    'timestamp_completed': analysis['timestampCompleted'],
                 }
-                all_sample_analyses[sample_id].append(analysis_entry)
+                all_sg_analyses[sg_id].append(analysis_entry)
 
-        if all_sample_analyses:
-            for sample_without_cram, completed_analyses in all_sample_analyses.items():
+        if all_sg_analyses:
+            for sg_without_cram, completed_analyses in all_sg_analyses.items():
                 for completed_analysis in completed_analyses:
                     logging.warning(
-                        f'{sample_without_cram} missing CRAM but has analysis {completed_analysis}'
+                        f'{self.dataset} :: SG {sg_without_cram} missing CRAM but has analysis {completed_analysis}'
                     )
 
-    def get_complete_and_incomplete_samples(
+    def get_complete_and_incomplete_sgs(
         self,
-        sample_internal_to_external_id_map: dict[str, str],
-        sample_cram_paths: dict[str, dict[int, str]],
+        assay_sg_id_map: dict[int, str],
+        sg_cram_paths: dict[str, dict[int, str]],
     ) -> dict[str, Any]:
         """
-        Returns a dictionary containing two categories of samples:
-         - the completed samples which have finished aligning and have a cram, as a dict mapping
-            the sample_id to the analysis IDs
-         - the incomplete samples where the alignment hasn't completed and no cram exists, as a list
+        Returns a dictionary containing two categories of sequencing groups:
+         - the completed sgs which have finished aligning and have a cram, as a dict mapping
+            the sg_id to the analysis_ids
+         - the incomplete sgs where the alignment hasn't completed and no cram exists, as a list
         """
         # Get all the unique cram paths to check
         cram_paths = set()
-        for analyses in sample_cram_paths.values():
+        for analyses in sg_cram_paths.values():
             cram_paths.update(list(analyses.values()))
 
         # Check the analysis paths actually point to crams that exist in the bucket
@@ -411,239 +359,246 @@ class GenericAuditor(AuditHelper):
         )
 
         # Incomplete samples initialised as the list of samples without a valid analysis cram output path
-        incomplete_samples = set(sample_internal_to_external_id_map.keys()).difference(
-            set(sample_cram_paths.keys())
+        incomplete_sgs = set(assay_sg_id_map.values()).difference(
+            set(sg_cram_paths.keys())
         )
 
-        # Completed samples are those whose completed cram output path exists in the bucket at the same path
-        completed_samples = defaultdict(list)
-        for sample_internal_id, analyses in sample_cram_paths.items():
+        # Completed sgs are those whose completed cram output path exists in the bucket at the same path
+        completed_sgs = defaultdict(list)
+        for sg_id, analyses in sg_cram_paths.items():
             for analysis_id, cram_path in analyses.items():
                 if cram_path in crams_in_bucket:
-                    completed_samples[sample_internal_id].append(analysis_id)
+                    completed_sgs[sg_id].append(analysis_id)
                     continue
-                incomplete_samples.update(sample_internal_id)
+                incomplete_sgs.update(sg_id)
 
-        if (
-            incomplete_samples
-        ):  # Report on samples without CRAMs especially if other analysis types have been created
-            logging.info(f'Samples without CRAMs found: {list(incomplete_samples)}')
-            self.analyses_for_samples_without_crams(list(incomplete_samples))
+        if incomplete_sgs:
+            logging.warning(
+                f'{self.dataset} :: {len(incomplete_sgs)} SGs without CRAMs found: {list(incomplete_sgs)}'
+            )
+            self.analyses_for_sgs_without_crams(list(incomplete_sgs))
 
-        return {'complete': completed_samples, 'incomplete': list(incomplete_samples)}
+        return {'complete': completed_sgs, 'incomplete': list(incomplete_sgs)}
 
-    async def check_for_uningested_or_moved_sequences(  # pylint: disable=R0914
+    async def check_for_uningested_or_moved_assays(  # pylint: disable=R0914
         self,
         bucket_name: str,
-        sequence_filepaths_filesizes: dict[int, list[tuple[str, int]]],
-        completed_samples: dict[str, list[int]],
-        seq_id_sample_id_map: dict[int, str],
-        sample_id_internal_external_map: dict[str, str],
+        assay_filepaths_filesizes: dict[int, list[tuple[str, int]]],
+        completed_sgs: dict[str, list[int]],
+        sg_sample_id_map: dict[str, str],
+        assay_sg_id_map: dict[int, str],
+        sample_internal_external_id_map: dict[str, str],
     ):
         """
-        Compares the sequences in a Metamist dataset to the sequences in the main-upload bucket
+        Compares the assays in a Metamist dataset to the assays in the main-upload bucket
 
-        Input: The dataset name, the {sequence_id : read_paths} mapping, the sequence file types,
-               and the sample internal -> external ID mapping.
-        Returns: 1. Paths to sequences that have not yet been ingested - checks if any completed
+        Input: The dataset name, the {assay_id : read_paths} mapping, the assay file types,
+               and the sample internal -> external id mapping.
+        Returns: 1. Paths to assays that have not yet been ingested - checks if any completed
                     sample external IDs are in the filename and includes this in output.
-                 2. A dict mapping sequence IDs to GS filepaths that have been ingested,
+                 2. A dict mapping assay IDs to GS filepaths that have been ingested,
                     but where the path in the bucket is different to the path for this
-                    sequence in Metamist. If the filenames and file sizes match,
-                    these are identified as sequence files that have been moved from
+                    assay in Metamist. If the filenames and file sizes match,
+                    these are identified as assay files that have been moved from
                     their original location to a new location.
                  3. The paths saved in metamist for the read data that has been moved. These paths go nowhere.
         """
-        # Get all the paths to sequence data anywhere in the main-upload bucket
-        sequence_paths_in_bucket = self.find_sequence_files_in_gcs_bucket(
+        # Get all the paths to assay data anywhere in the main-upload bucket
+        assay_paths_in_bucket = self.find_assay_files_in_gcs_bucket(
             bucket_name, self.file_types
         )
 
-        # Flatten all the Metamist sequence file paths and sizes into a single list
-        sequence_paths_sizes_in_metamist: list[tuple[str, int]] = []
-        for sequence in sequence_filepaths_filesizes.values():
-            sequence_paths_sizes_in_metamist.extend(sequence)
+        # Flatten all the Metamist assay file paths and sizes into a single list
+        assay_paths_sizes_in_metamist: list[tuple[str, int]] = []
+        for assay in assay_filepaths_filesizes.values():
+            assay_paths_sizes_in_metamist.extend(assay)
 
         # Find the paths that exist in the bucket and not in metamist
-        sequence_paths_in_metamist = [
-            path_size[0] for path_size in sequence_paths_sizes_in_metamist
+        assay_paths_in_metamist = [
+            path_size[0] for path_size in assay_paths_sizes_in_metamist
         ]
-        uningested_sequence_paths = set(sequence_paths_in_bucket).difference(
-            set(sequence_paths_in_metamist)
+        uningested_assay_paths = set(assay_paths_in_bucket).difference(
+            set(assay_paths_in_metamist)
         )
-        # These metamist paths lead nowhere so we can go ahead and ignore them
-        metamist_paths_to_nowhere = set(sequence_paths_in_metamist).difference(
-            set(sequence_paths_in_bucket)
+        # Find the paths that exist in metamist and not in the bucket
+        metamist_paths_to_nowhere = set(assay_paths_in_metamist).difference(
+            set(assay_paths_in_bucket)
         )
 
         # Strip the metamist paths into just filenames
         # Map each file name to its file size and path
-        metamist_sequence_file_size_map = {
+        metamist_assay_file_size_map = {
             os.path.basename(path_size[0]): path_size[1]
-            for path_size in sequence_paths_sizes_in_metamist
+            for path_size in assay_paths_sizes_in_metamist
         }
-        metamist_sequence_file_path_map = {
+        metamist_assay_file_path_map = {
             os.path.basename(path_size[0]): path_size[0]
-            for path_size in sequence_paths_sizes_in_metamist
+            for path_size in assay_paths_sizes_in_metamist
         }
 
-        # Identify if any paths are to files that have actually just been moved by checking if they are in the bucket but not metamist
+        # Identify if any paths are to files that have actually just been moved
+        # by checking if they are in the bucket but not metamist
         ingested_and_moved_filepaths = []
-        new_sequence_path_sizes = {}
-        for path in uningested_sequence_paths:
+        new_assay_path_sizes = {}
+        for path in uningested_assay_paths:
             filename = os.path.basename(path)
             # If the file in the bucket has the exact same name and size as one in metamist, assume its the same
-            if filename in metamist_sequence_file_size_map.keys():
+            if filename in metamist_assay_file_size_map.keys():
                 filesize = await self.file_size(path)
-                if filesize == metamist_sequence_file_size_map.get(filename):
+                if filesize == metamist_assay_file_size_map.get(filename):
                     ingested_and_moved_filepaths.append(
-                        (path, metamist_sequence_file_path_map.get(filename))
+                        (path, metamist_assay_file_path_map.get(filename))
                     )
-                    new_sequence_path_sizes[path] = filesize
+                    new_assay_path_sizes[path] = filesize
         logging.info(
             f'Found {len(ingested_and_moved_filepaths)} ingested files that have been moved'
         )
 
         # If the file has just been moved, we consider it ingested
-        uningested_sequence_paths -= {
+        uningested_assay_paths -= {
             bucket_path for bucket_path, _ in ingested_and_moved_filepaths
         }
 
-        # Check the list of uningested paths to see if any of them contain sample IDs for ingested samples
+        # Check the list of uningested paths to see if any of them contain sample ids for ingested samples
         # This could happen when we ingest a fastq read pair for a sample, and additional read files were provided
         # but not ingested, such as bams and vcfs.
         uningested_reads: dict[str, list[tuple[str, str]]] = defaultdict(
-            list, {k: [] for k in uningested_sequence_paths}
+            list, {k: [] for k in uningested_assay_paths}
         )
-        for sample_id, analysis_ids in completed_samples.items():
+        for sg_id, analysis_ids in completed_sgs.items():
             try:
-                sample_ext_id = sample_id_internal_external_map[sample_id]
-                for uningested_sequence in uningested_sequence_paths:
-                    if sample_ext_id not in uningested_sequence:
+                sample_id = sg_sample_id_map[sg_id]
+                sample_ext_id = sample_internal_external_id_map[sample_id]
+                for uningested_assay in uningested_assay_paths:
+                    if sample_ext_id not in uningested_assay:
                         continue
-                    uningested_reads[uningested_sequence].append(
-                        (sample_id, sample_ext_id))
+                    uningested_reads[uningested_assay].append(
+                        (sg_id, sample_id, sample_ext_id)
+                    )
             except KeyError:
                 logging.warning(
-                    f'{sample_id} from analyses: {analysis_ids} not found in sample map.'
+                    f'{sg_id} from analyses: {analysis_ids} not found in SG-sample map.'
                 )
 
-        # flip the sequence id : reads mapping to identify sequence IDs by their read paths
-        reads_sequences = {}
-        for sequence_id, reads_sizes in sequence_filepaths_filesizes.items():
+        # flip the assay id : reads mapping to identify assays by their reads
+        reads_assays = {}
+        for assay_id, reads_sizes in assay_filepaths_filesizes.items():
             for read_size in reads_sizes:
-                reads_sequences[read_size[0]] = sequence_id
+                reads_assays[read_size[0]] = assay_id
 
-        # Collect the sequences for files that have been ingested and moved to a different bucket location
-        sequences_moved_paths = []
+        # Collect the assays for files that have been ingested and moved to a different bucket location
+        assays_moved_paths = []
         for bucket_path, metamist_path in ingested_and_moved_filepaths:
-            seq_id = reads_sequences.get(metamist_path)
-            sample_id = seq_id_sample_id_map.get(seq_id)
-            analysis_ids = completed_samples.get(sample_id)
-            if sample_id not in EXCLUDED_SAMPLES:
-                filesize = new_sequence_path_sizes[bucket_path]
-                sequences_moved_paths.append(
-                    SequenceReportEntry(
-                        sample_id=sample_id,
-                        sequence_id=seq_id,
-                        sequence_file_path=bucket_path,
+            assay_id = reads_assays.get(metamist_path)
+            sg_id = assay_sg_id_map.get(assay_id)
+            analysis_ids = completed_sgs.get(sg_id)
+            if sg_id not in AuditHelper.EXCLUDED_SGS and analysis_ids:
+                filesize = new_assay_path_sizes[bucket_path]
+                assays_moved_paths.append(
+                    AssayReportEntry(
+                        sg_id=sg_id,
+                        assay_id=assay_id,
+                        assay_file_path=bucket_path,
                         analysis_ids=analysis_ids,
                         filesize=filesize,
                     )
                 )
 
-        return uningested_reads, sequences_moved_paths, metamist_paths_to_nowhere
+        return uningested_reads, assays_moved_paths, metamist_paths_to_nowhere
 
     async def get_reads_to_delete_or_ingest(
         self,
         bucket_name: str,
-        completed_samples: dict[str, list[int]],
-        sequence_filepaths_filesizes: dict[int, list[tuple[str, int]]],
-        seq_id_sample_id_map: dict[int, str],
-        sample_id_internal_external_map: dict[str, str],
+        completed_sgs: dict[str, list[int]],
+        assay_filepaths_filesizes: dict[int, list[tuple[str, int]]],
+        sg_sample_id_map: dict[str, str],
+        assay_sg_id_map: dict[int, str],
+        sample_internal_external_id_map: dict[str, str],
     ) -> tuple[list, list]:
         """
         Inputs: 1. List of samples which have completed CRAMs
-                2. Dictionary mapping of sequence IDs to sequence file paths and file sizes
-                3. Dictionary mapping sample IDs to sequence IDs
-                4. Dictionary mapping sequence IDs to sample IDs
-        Returns a tuple of two lists, each containing sequences IDs and sequence file paths.
+                2. Dictionary mapping of assay IDs to assay file paths and file sizes
+                3. Dictionary mapping sample IDs to assay IDs
+                4. Dictionary mapping assay IDs to sample IDs
+        Returns a tuple of two lists, each containing assays IDs and assay file paths.
         The first containins reads which can be deleted, the second containing reads to ingest.
-        The sample ID, sequence ID, and analysis ID (of completed cram) are included in the delete list.
+        The sample id, assay id, and analysis id (of completed cram) are included in the delete list.
         """
-        # Check for uningested sequence data that may be hiding or sequence data that has been moved
+        # Check for uningested assay data that may be hiding or assay data that has been moved
         (
             reads_to_ingest,
-            moved_sequences_to_delete,
+            moved_assays_to_delete,
             metamist_paths_to_nowhere,
-        ) = await self.check_for_uningested_or_moved_sequences(
+        ) = await self.check_for_uningested_or_moved_assays(
             bucket_name,
-            sequence_filepaths_filesizes,
-            completed_samples,
-            seq_id_sample_id_map,
-            sample_id_internal_external_map,
+            assay_filepaths_filesizes,
+            completed_sgs,
+            sg_sample_id_map,
+            assay_sg_id_map,
+            sample_internal_external_id_map,
         )
 
-        # Create a mapping of sample ID: sequence ID - use defaultdict in case a sample has several sequences
-        sample_id_seq_id_map: dict[str, list[int]] = defaultdict(list)
-        for sequence, sample in seq_id_sample_id_map.items():
-            sample_id_seq_id_map[sample].append(sequence)
+        # Create a mapping of sg id: assay id - use defaultdict in case a sg has several assays
+        sg_assays_id_map: dict[str, list[int]] = defaultdict(list)
+        for assay_id, sg_id in assay_sg_id_map.items():
+            sg_assays_id_map[sg_id].append(assay_id)
 
-        sequence_reads_to_delete = []
-        for sample_id, analysis_ids in completed_samples.items():
-            if sample_id in EXCLUDED_SAMPLES:
+        assay_reads_to_delete = []
+        for sg_id, analysis_ids in completed_sgs.items():
+            if sg_id in AuditHelper.EXCLUDED_SGS:
                 continue
-            seq_ids = sample_id_seq_id_map[sample_id]
-            for seq_id in seq_ids:
-                seq_read_paths = sequence_filepaths_filesizes[seq_id]
-                for path, size in seq_read_paths:
+            assay_ids = sg_assays_id_map[sg_id]
+            for assay_id in assay_ids:
+                assay_read_paths = assay_filepaths_filesizes[assay_id]
+                for path, size in assay_read_paths:
                     if path in metamist_paths_to_nowhere:
                         continue
                     filesize = size
-                    sequence_reads_to_delete.append(
-                        SequenceReportEntry(
-                            sample_id=sample_id,
-                            sequence_id=seq_id,
-                            sequence_file_path=path,
+                    assay_reads_to_delete.append(
+                        AssayReportEntry(
+                            sg_id=sg_id,
+                            assay_id=assay_id,
+                            assay_file_path=path,
                             analysis_ids=analysis_ids,
                             filesize=filesize,
                         )
                     )
 
-        reads_to_delete = sequence_reads_to_delete + moved_sequences_to_delete
+        reads_to_delete = assay_reads_to_delete + moved_assays_to_delete
 
         return reads_to_delete, reads_to_ingest
 
     @staticmethod
     def find_crams_for_reads_to_ingest(
         reads_to_ingest: dict[str, list],
-        sample_cram_paths: dict[str, dict[int, str]],
+        sg_cram_paths: dict[str, dict[int, str]],
     ) -> list[tuple[str, str, str, int, str]]:
         """
         Compares the external sample IDs for samples with completed CRAMs against the
         uningested read files. This may turn up results for cases where multiple read types
         have been provided for a sample, but only one type was ingested and used for alignment.
         """
-        possible_sequence_ingests = []
-        for sequence_path, samples in reads_to_ingest.items():
-            if not samples:
+        possible_assay_ingests = []
+        for assay_path, sample_tuples in reads_to_ingest.items():
+            if not sample_tuples:
                 # If no samples detected in filename, add the path in an empty tuple
-                possible_sequence_ingests.append((sequence_path, '', '', 0, ''))
+                possible_assay_ingests.append((assay_path, '', '', '', 0, ''))
                 continue
-            for sample in samples:
-                # Else get the completed CRAM analysis ID and path for the sample
-                sample_internal_id, sample_ext_id = sample
-                sample_cram = sample_cram_paths[sample_internal_id]
-                analysis_id = int(list(sample_cram.keys())[0])
-                cram_path = sample_cram[analysis_id]
-                possible_sequence_ingests.append(
+            for sample_tuple in sample_tuples:
+                # Else get the completed CRAM analysis id and path for the sample
+                sg_id, sample_id, sample_external_id = sample_tuple
+                sg_cram = sg_cram_paths[sg_id]
+                analysis_id = int(list(sg_cram.keys())[0])
+                cram_path = sg_cram[analysis_id]
+                possible_assay_ingests.append(
                     (
-                        sequence_path,
-                        sample_ext_id,
-                        sample_internal_id,
+                        assay_path,
+                        sg_id,
+                        sample_id,
+                        sample_external_id,
                         analysis_id,
                         cram_path,
                     )
                 )
 
-        return possible_sequence_ingests
+        return possible_assay_ingests

--- a/test/test_generic_auditor.py
+++ b/test/test_generic_auditor.py
@@ -22,15 +22,29 @@ class TestGenericAuditor(unittest.TestCase):
                 'participants': [
                     {
                         'id': 1,
-                        'samples': [{'id': 'CPG123', 'sequences': [{'id': 1}]}],
+                        'externalId': 'P01',
+                        'samples': [
+                            {
+                                'id': 'XPG123',
+                                'sequencingGroups': [
+                                    {'id': 'CPG123', 'assays': [{'id': 1}]}
+                                ],
+                            }
+                        ],
                     },
                     {
                         'id': 2,
+                        'externalId': 'P02',
                         'samples': [
-                            {'id': 'CPG456', 'sequences': [{'id': 2}, {'id': 3}]}
+                            {
+                                'id': 'XPG456',
+                                'sequencingGroups': [
+                                    {'id': 'CPG456', 'assays': [{'id': 2}, {'id': 3}]}
+                                ],
+                            }
                         ],
                     },
-                    {'id': 3, 'samples': []},
+                    {'id': 3, 'externalId': 'P01', 'samples': []},
                 ],
             }
         }
@@ -38,11 +52,25 @@ class TestGenericAuditor(unittest.TestCase):
         expected_participants = [
             {
                 'id': 1,
-                'samples': [{'id': 'CPG123', 'sequences': [{'id': 1}]}],
+                'externalId': 'P01',
+                'samples': [
+                    {
+                        'id': 'XPG123',
+                        'sequencingGroups': [{'id': 'CPG123', 'assays': [{'id': 1}]}],
+                    }
+                ],
             },
             {
                 'id': 2,
-                'samples': [{'id': 'CPG456', 'sequences': [{'id': 2}, {'id': 3}]}],
+                'externalId': 'P02',
+                'samples': [
+                    {
+                        'id': 'XPG456',
+                        'sequencingGroups': [
+                            {'id': 'CPG456', 'assays': [{'id': 2}, {'id': 3}]}
+                        ],
+                    }
+                ],
             },
         ]
 
@@ -50,7 +78,7 @@ class TestGenericAuditor(unittest.TestCase):
 
         self.assertListEqual(expected_participants, participant_data)
 
-    def test_get_genome_sequence_mapping(self):
+    def test_get_assay_map_from_participants_genome(self):
         """Only genome sequences should be mapped to the sample ID"""
         auditor = GenericAuditor(
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
@@ -61,145 +89,198 @@ class TestGenericAuditor(unittest.TestCase):
                 'id': 1,
                 'samples': [
                     {
-                        'id': 'CPG123',
+                        'id': 'XPG123',
                         'externalId': 'EX01',
-                        'sequences': [
+                        'sequencingGroups': [
                             {
-                                'id': 1,
+                                'id': 'CPG123',
                                 'type': 'genome',
-                                'meta': {
-                                    'reads': {
-                                        'location': 'gs://cpg-dataset-main-upload/read.fq',
-                                        'size': 12,
-                                    }
-                                },
+                                'assays': [
+                                    {
+                                        'id': 1,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/read.fq',
+                                                    'size': 11,
+                                                }
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        'id': 2,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/R1.fq',
+                                                    'size': 12,
+                                                },
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/R2.fq',
+                                                    'size': 13,
+                                                },
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        'id': 3,
+                                        'meta': {
+                                            'reads': [{'location': 'test', 'size': 0}]
+                                        },
+                                    },
+                                ],
                             },
                             {
-                                'id': 2,
-                                'type': 'genome',
-                                'meta': {
-                                    'reads': [
-                                        {
-                                            'location': 'gs://cpg-dataset-main-upload/R1.fq',
-                                            'size': 12,
-                                        },
-                                        {
-                                            'location': 'gs://cpg-dataset-main-upload/R2.fq',
-                                            'size': 13,
-                                        },
-                                    ]
-                                },
-                            },
-                            {
-                                'id': 3,
+                                'id': 'CPG456',
                                 'type': 'exome',
-                                'meta': {'reads': {'location': 'test', 'size': 0}},
+                                'assays': [
+                                    {
+                                        'id': 4,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/exome/read.fq',
+                                                    'size': 14,
+                                                }
+                                            ]
+                                        },
+                                    }
+                                ],
                             },
                         ],
                     },
                 ],
-            },
+            }
         ]
-        seq_sample_id_map, seq_reads_sizes = auditor.get_sequence_map_from_participants(
-            participants
-        )
 
-        expected_mapping = {1: 'CPG123', 2: 'CPG123'}
+        (
+            sg_sample_id_map,
+            assay_sg_id_map,
+            assay_paths_sizes,
+        ) = auditor.get_assay_map_from_participants(participants)
+
+        expected_sg_sample_mapping = {'CPG123': 'XPG123'}
+        expected_assay_sg_mapping = {1: 'CPG123', 2: 'CPG123', 3: 'CPG123'}
         expected_read_sizes = {
             1: [
-                ('gs://cpg-dataset-main-upload/read.fq', 12),
+                ('gs://cpg-dataset-main-upload/read.fq', 11),
             ],
             2: [
                 ('gs://cpg-dataset-main-upload/R1.fq', 12),
                 ('gs://cpg-dataset-main-upload/R2.fq', 13),
             ],
+            3: [
+                ('test', 0),
+            ],
         }
 
-        self.assertDictEqual(seq_sample_id_map, expected_mapping)
-        self.assertDictEqual(seq_reads_sizes, expected_read_sizes)
+        self.assertDictEqual(sg_sample_id_map, expected_sg_sample_mapping)
+        self.assertDictEqual(assay_sg_id_map, expected_assay_sg_mapping)
+        self.assertDictEqual(assay_paths_sizes, expected_read_sizes)
 
-    # def test_get_all_sequence_mapping_list_reads(self):
-    #     """Both genome and exome sequences should be mapped to the sample IDs"""
-    #     auditor = GenericAuditor(
-    #         dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
-    #     )
-    #     participants = [
-    #         {
-    #             'externalId': 'EX01',
-    #             'id': 1,
-    #             'samples': [
-    #                 {
-    #                     'id': 'CPG123',
-    #                     'externalId': 'EX01',
-    #                     'sequences': [
-    #                         {
-    #                             'id': 1,
-    #                             'type': 'genome',
-    #                             'meta': {
-    #                                 'reads': [
-    #                                     {
-    #                                         'location': 'gs://cpg-dataset-main-upload/R1.fq',
-    #                                         'size': 12,
-    #                                     },
-    #                                     {
-    #                                         'location': 'gs://cpg-dataset-main-upload/R2.fq',
-    #                                         'size': 13,
-    #                                     },
-    #                                 ]
-    #                             },
-    #                         },
-    #                     ],
-    #                 },
-    #             ],
-    #         },
-    #         {
-    #             'externalId': 'EX02',
-    #             'id': 2,
-    #             'samples': [
-    #                 {
-    #                     'id': 'CPG456',
-    #                     'externalId': 'EX02',
-    #                     'sequences': [
-    #                         {
-    #                             'id': 2,
-    #                             'type': 'exome',
-    #                             'meta': {
-    #                                 'reads': [
-    #                                     {
-    #                                         'location': 'gs://cpg-dataset-main-upload/exomes/R1.fq',
-    #                                         'size': 14,
-    #                                     },
-    #                                     {
-    #                                         'location': 'gs://cpg-dataset-main-upload/exomes/R2.fq',
-    #                                         'size': 15,
-    #                                     },
-    #                                 ]
-    #                             },
-    #                         },
-    #                     ],
-    #                 },
-    #             ],
-    #         },
-    #     ]
-    #     seq_sample_id_map, seq_reads_sizes = auditor.get_sequence_map_from_participants(
-    #         participants
-    #     )
-    #     expected_mapping = {1: 'CPG123', 2: 'CPG456'}
-    #     expected_read_sizes = {
-    #         1: [
-    #             ('gs://cpg-dataset-main-upload/R1.fq', 12),
-    #             ('gs://cpg-dataset-main-upload/R2.fq', 13),
-    #         ],
-    #         2: [
-    #             ('gs://cpg-dataset-main-upload/exomes/R1.fq', 14),
-    #             ('gs://cpg-dataset-main-upload/exomes/R2.fq', 15),
-    #         ],
-    #     }
-    #
-    #     self.assertDictEqual(seq_sample_id_map, expected_mapping)
-    #     self.assertDictEqual(seq_reads_sizes, expected_read_sizes)
+    def test_get_assay_map_from_participants_all(self):
+        """Both genome and exome sequences should be mapped to the sample IDs"""
+        auditor = GenericAuditor(
+            dataset='dev', sequencing_type=['genome', 'exome'], file_types=('fastq',)
+        )
+        participants = [
+            {
+                'externalId': 'EX01',
+                'id': 1,
+                'samples': [
+                    {
+                        'id': 'XPG123',
+                        'externalId': 'EX01',
+                        'sequencingGroups': [
+                            {
+                                'id': 'CPG123',
+                                'type': 'genome',
+                                'assays': [
+                                    {
+                                        'id': 1,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/read.fq',
+                                                    'size': 11,
+                                                }
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        'id': 2,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/R1.fq',
+                                                    'size': 12,
+                                                },
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/R2.fq',
+                                                    'size': 13,
+                                                },
+                                            ]
+                                        },
+                                    },
+                                    {
+                                        'id': 3,
+                                        'meta': {
+                                            'reads': [{'location': 'test', 'size': 0}]
+                                        },
+                                    },
+                                ],
+                            },
+                            {
+                                'id': 'CPG456',
+                                'type': 'exome',
+                                'assays': [
+                                    {
+                                        'id': 4,
+                                        'meta': {
+                                            'reads': [
+                                                {
+                                                    'location': 'gs://cpg-dataset-main-upload/exome/read.fq',
+                                                    'size': 14,
+                                                }
+                                            ]
+                                        },
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ]
+        (
+            sg_sample_id_map,
+            assay_sg_id_map,
+            assay_paths_sizes,
+        ) = auditor.get_assay_map_from_participants(participants)
 
-    def test_get_sequence_mapping_logging(self):
+        expected_sg_sample_mapping = {'CPG123': 'XPG123', 'CPG456': 'XPG123'}
+        expected_assay_sg_mapping = {1: 'CPG123', 2: 'CPG123', 3: 'CPG123', 4: 'CPG456'}
+        expected_read_sizes = {
+            1: [
+                ('gs://cpg-dataset-main-upload/read.fq', 11),
+            ],
+            2: [
+                ('gs://cpg-dataset-main-upload/R1.fq', 12),
+                ('gs://cpg-dataset-main-upload/R2.fq', 13),
+            ],
+            3: [
+                ('test', 0),
+            ],
+            4: [
+                ('gs://cpg-dataset-main-upload/exome/read.fq', 14),
+            ],
+        }
+
+        self.assertDictEqual(sg_sample_id_map, expected_sg_sample_mapping)
+        self.assertDictEqual(assay_sg_id_map, expected_assay_sg_mapping)
+        self.assertDictEqual(assay_paths_sizes, expected_read_sizes)
+
+    def test_get_sequence_mapping_error_logging(self):
         """If the sequence reads meta field maps to a raw string, logging.error triggers"""
         auditor = GenericAuditor(
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
@@ -210,15 +291,22 @@ class TestGenericAuditor(unittest.TestCase):
                 'id': 1,
                 'samples': [
                     {
-                        'id': 'CPG123',
+                        'id': 'XPG123',
                         'externalId': 'EX01',
-                        'sequences': [
+                        'sequencingGroups': [
                             {
-                                'id': 1,
+                                'id': 'CPG123',
                                 'type': 'genome',
-                                'meta': {
-                                    'reads': 'gs://cpg-dataset-main-upload/read.cram'
-                                },
+                                'assays': [
+                                    {
+                                        'id': 1,
+                                        'meta': {
+                                            'reads': [
+                                                'gs://cpg-dataset-main-upload/read.fq',
+                                            ]
+                                        },
+                                    },
+                                ],
                             },
                         ],
                     },
@@ -226,11 +314,49 @@ class TestGenericAuditor(unittest.TestCase):
             },
         ]
         with self.assertLogs(level='ERROR') as log:
-            _, _ = auditor.get_sequence_map_from_participants(participants)
+            _, _, _ = auditor.get_assay_map_from_participants(participants)
             self.assertEqual(len(log.output), 1)
             self.assertEqual(len(log.records), 1)
             self.assertIn(
-                "Invalid read type: <class 'str'>: gs://cpg-dataset-main-upload/read.cram",
+                "ERROR:root:dev :: Got <class 'str'> read for SG CPG123, expected dict: gs://cpg-dataset-main-upload/read.fq",
+                log.output[0],
+            )
+
+    def test_get_sequence_mapping_warning_logging(self):
+        """If the sequence reads meta field is missing, logging.warning triggers"""
+        auditor = GenericAuditor(
+            dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
+        )
+        participants = [
+            {
+                'externalId': 'EX01',
+                'id': 1,
+                'samples': [
+                    {
+                        'id': 'XPG123',
+                        'externalId': 'EX01',
+                        'sequencingGroups': [
+                            {
+                                'id': 'CPG123',
+                                'type': 'genome',
+                                'assays': [
+                                    {
+                                        'id': 1,
+                                        'meta': {},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ]
+        with self.assertLogs(level='WARNING') as log:
+            _, _, _ = auditor.get_assay_map_from_participants(participants)
+            self.assertEqual(len(log.output), 1)
+            self.assertEqual(len(log.records), 1)
+            self.assertIn(
+                'WARNING:root:dev :: SG CPG123 assay 1 has no reads field',
                 log.output[0],
             )
 
@@ -242,102 +368,109 @@ class TestGenericAuditor(unittest.TestCase):
         )
         mock_query.side_effect = [
             {
-                'sample': {
-                    'id': 'CPG123',
-                    'analyses': [
-                        {
-                            'id': 1,
-                            'meta': {
-                                'sequencing_type': 'genome',
+                'sequencingGroups': [
+                    {
+                        'id': 'CPG123',
+                        'type': 'genome',
+                        'analyses': [
+                            {
+                                'id': 1,
+                                'meta': {
+                                    'sequencing_type': 'genome',
+                                    'sample_ids': [
+                                        'CPG123',
+                                    ],
+                                },
+                                'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
                             },
-                            'sample_ids': [
-                                'CPG123',
-                            ],
-                            'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
-                        },
-                    ],
-                },
-            },
-            {
-                'sample': {
-                    'id': 'CPG456',
-                    'analyses': [
-                        {
-                            'id': 2,
-                            'meta': {
-                                'sequencing_type': 'exome',
+                        ],
+                    },
+                    {
+                        'id': 'CPG456',
+                        'type': 'exome',
+                        'analyses': [
+                            {
+                                'id': 2,
+                                'meta': {
+                                    'sequencing_type': 'exome',
+                                    'sample_ids': [
+                                        'CPG456',
+                                    ],
+                                },
+                                'output': 'gs://cpg-dataset-main/exome/cram/CPG123.cram',
                             },
-                            'sample_ids': [
-                                'CPG456',
-                            ],
-                            'output': 'gs://cpg-dataset-main/exome/cram/CPG123.cram',
-                        },
-                    ],
-                },
-            },
+                        ],
+                    },
+                ]
+            }
         ]
 
-        test_result = auditor.get_analysis_cram_paths_for_dataset_samples(
-            sample_internal_to_external_id_map={'CPG123': 'EXT123'}
+        test_result = auditor.get_analysis_cram_paths_for_dataset_sgs(
+            assay_sg_id_map={1: 'CPG123'}
         )
-
         expected_result = {'CPG123': {1: 'gs://cpg-dataset-main/cram/CPG123.cram'}}
 
         self.assertDictEqual(test_result, expected_result)
 
-    # @patch('metamist.audit.generic_auditor.query')
-    # def test_query_genome_and_exome_analyses_crams(self, mock_query):
-    #     """Test that both the genome and exome analysis crams for a sample map dictionary are returned"""
-    #     auditor = GenericAuditor(
-    #         dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
-    #     )
-    #     mock_query.side_effect = [
-    #         {
-    #             'sample': {
-    #                 'id': 'CPG123',
-    #                 'analyses': [
-    #                     {
-    #                         'id': 1,
-    #                         'meta': {
-    #                             'sequencing_type': 'genome',
-    #                         },
-    #                         'sample_ids': [
-    #                             'CPG123',
-    #                         ],
-    #                         'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
-    #                     },
-    #                 ],
-    #             },
-    #         },
-    #         {
-    #             'sample': {
-    #                 'id': 'CPG456',
-    #                 'analyses': [
-    #                     {
-    #                         'id': 2,
-    #                         'meta': {
-    #                             'sequencing_type': 'exome',
-    #                         },
-    #                         'sample_ids': [
-    #                             'CPG456',
-    #                         ],
-    #                         'output': 'gs://cpg-dataset-main/exome/cram/CPG123.cram',
-    #                     },
-    #                 ],
-    #             },
-    #         },
-    #     ]
-    #
-    #     test_result = auditor.get_analysis_cram_paths_for_dataset_samples(
-    #         sample_internal_to_external_id_map={'CPG123': 'EXT123', 'CPG456': 'EXT456'}
-    #     )
-    #
-    #     expected_result = {
-    #         'CPG123': {1: 'gs://cpg-dataset-main/cram/CPG123.cram'},
-    #         'CPG456': {2: 'gs://cpg-dataset-main/exome/cram/CPG123.cram'},
-    #     }
-    #
-    #     self.assertDictEqual(test_result, expected_result)
+    @patch('metamist.audit.generic_auditor.query')
+    def test_query_genome_and_exome_analyses_crams(self, mock_query):
+        """Test that both the genome and exome analysis crams for a sample map dictionary are returned"""
+        auditor = GenericAuditor(
+            dataset='dev', sequencing_type=['genome', 'exome'], file_types=('fastq',)
+        )
+        mock_query.side_effect = [
+            {
+                'sequencingGroups': [
+                    {
+                        'id': 'CPG123',
+                        'type': 'genome',
+                        'analyses': [
+                            {
+                                'id': 1,
+                                'meta': {
+                                    'sequencing_type': 'genome',
+                                    'sample_ids': [
+                                        'CPG123',
+                                    ],
+                                },
+                                'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
+                            },
+                        ],
+                    }
+                ]
+            },
+            {
+                'sequencingGroups': [
+                    {
+                        'id': 'CPG456',
+                        'type': 'exome',
+                        'analyses': [
+                            {
+                                'id': 2,
+                                'meta': {
+                                    'sequencing_type': 'exome',
+                                    'sample_ids': [
+                                        'CPG456',
+                                    ],
+                                },
+                                'output': 'gs://cpg-dataset-main/exome/cram/CPG123.cram',
+                            },
+                        ],
+                    },
+                ]
+            },
+        ]
+
+        test_result = auditor.get_analysis_cram_paths_for_dataset_sgs(
+            assay_sg_id_map={1: 'CPG123', 2: 'CPG456'}
+        )
+
+        expected_result = {
+            'CPG123': {1: 'gs://cpg-dataset-main/cram/CPG123.cram'},
+            'CPG456': {2: 'gs://cpg-dataset-main/exome/cram/CPG123.cram'},
+        }
+
+        self.assertDictEqual(test_result, expected_result)
 
     @patch('metamist.audit.generic_auditor.query')
     def test_query_broken_analyses_crams(self, mock_query):
@@ -349,26 +482,28 @@ class TestGenericAuditor(unittest.TestCase):
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
         )
         mock_query.return_value = {
-            'sample': {
-                'id': 'CPG123',
-                'analyses': [
-                    {
-                        'id': 1,
-                        'meta': {
-                            'sequence_type': 'genome',
+            'sequencingGroups': [
+                {
+                    'id': 'CPG123',
+                    'analyses': [
+                        {
+                            'id': 1,
+                            'meta': {
+                                'sequence_type': 'genome',
+                            },
+                            'sample_ids': [
+                                'CPG123',
+                            ],
+                            'output': '',
                         },
-                        'sample_ids': [
-                            'CPG123',
-                        ],
-                        'output': '',
-                    },
-                ],
-            },
+                    ],
+                },
+            ]
         }
 
         with self.assertRaises(ValueError):
-            auditor.get_analysis_cram_paths_for_dataset_samples(
-                sample_internal_to_external_id_map={'CPG123': 'EXT123'}
+            auditor.get_analysis_cram_paths_for_dataset_sgs(
+                assay_sg_id_map={1: 'CPG123'}
             )
 
     @patch('metamist.audit.generic_auditor.query')
@@ -378,87 +513,87 @@ class TestGenericAuditor(unittest.TestCase):
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
         )
         mock_query.return_value = {
-            'sample': {
-                'id': 'CPG123',
-                'analyses': [
-                    {
-                        'id': 1,
-                        'meta': {
-                            'sequencing_type': 'genome',
-                            'sample': 'CPG123',
+            'sequencingGroups': [
+                {
+                    'id': 'CPG123',
+                    'analyses': [
+                        {
+                            'id': 1,
+                            'meta': {
+                                'sequencing_type': 'genome',
+                                'sampling_id': 'CPG123',
+                            },
+                            'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
                         },
-                        'output': 'gs://cpg-dataset-main/cram/CPG123.cram',
-                    },
-                ],
-            }
+                    ],
+                }
+            ]
         }
 
         with self.assertLogs(level='WARNING') as log:
-            test_result = auditor.get_analysis_cram_paths_for_dataset_samples(
-                sample_internal_to_external_id_map={'CPG123': 'EXT123'}
+            _ = auditor.get_analysis_cram_paths_for_dataset_sgs(
+                assay_sg_id_map={1: 'CPG123'}
             )
             self.assertEqual(len(log.output), 1)
             self.assertEqual(len(log.records), 1)
             self.assertIn(
-                'Analysis: 1 missing "sample_ids" field. Using analysis["meta"].get("sample") instead.',
+                'WARNING:root:Analysis 1 missing sample or sequencing group field.',
                 log.output[0],
             )
 
-        expected_result = {'CPG123': {1: 'gs://cpg-dataset-main/cram/CPG123.cram'}}
-
-        self.assertDictEqual(test_result, expected_result)
-
     @patch('metamist.audit.generic_auditor.query')
-    def test_analyses_for_samples_without_crams(self, mock_query):
+    def test_analyses_for_sgs_without_crams(self, mock_query):
         """Log any analyses found for samples without completed CRAMs"""
         auditor = GenericAuditor(
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
         )
-        samples_without_crams = [  # noqa: B006
+        sgs_without_crams = [  # noqa: B006
             'CPG123',
         ]
 
         mock_query.return_value = {
-            'sample': {
-                'id': 'CPG123',
-                'analyses': [
-                    {
-                        'id': 1,
-                        'meta': {'sequencing_type': 'genome', 'sample': 'CPG123'},
-                        'output': 'gs://cpg-dataset-main/gvcf/CPG123.g.vcf.gz',
-                        'type': 'gvcf',
-                        'timestampCompleted': '2023-05-11T16:33:00',
-                    }
-                ],
-            }
+            'sequencingGroups': [
+                {
+                    'id': 'CPG123',
+                    'analyses': [
+                        {
+                            'id': 1,
+                            'meta': {'sequencing_type': 'genome', 'sample': 'CPG123'},
+                            'output': 'gs://cpg-dataset-main/gvcf/CPG123.g.vcf.gz',
+                            'type': 'gvcf',
+                            'timestampCompleted': '2023-05-11T16:33:00',
+                        }
+                    ],
+                }
+            ]
         }
 
         with self.assertLogs(level='WARNING') as log:
-            _ = auditor.analyses_for_samples_without_crams(samples_without_crams)
+            _ = auditor.analyses_for_sgs_without_crams(sgs_without_crams)
             self.assertEqual(len(log.output), 8)  # 8 analysis types checked
             self.assertEqual(len(log.records), 8)
             self.assertIn(
-                "WARNING:root:CPG123 missing CRAM but has analysis {'analysis_id': 1, 'analysis_type': 'gvcf', 'analysis_output': 'gs://cpg-dataset-main/gvcf/CPG123.g.vcf.gz', 'timestamp_completed': '2023-05-11T16:33:00'}",
-                log.output[6],
+                "WARNING:root:dev :: SG CPG123 missing CRAM but has analysis {'analysis_id': 1, 'analysis_type': 'gvcf', 'analysis_output': 'gs://cpg-dataset-main/gvcf/CPG123.g.vcf.gz', 'timestamp_completed': '2023-05-11T16:33:00'}",
+                log.output[0],
             )
 
-    def test_get_complete_and_incomplete_samples(self):
+    def test_get_complete_and_incomplete_sgs(self):
         """Report on samples that have completed CRAMs and those that dont"""
-        sample_map = {  # noqa: B006
-            'CPG123': 'EXT123',
-            'CPG456': 'EXT456',
-            'CPG789': 'EXT789',
+        assay_sg_id_map = {  # noqa: B006
+            1: 'CPG123',
+            2: 'CPG456',
+            3: 'CPG789',
         }
-        sample_cram_paths = {  # noqa: B006
+        sg_cram_paths = {  # noqa: B006
             'CPG123': {1: 'gs://cpg-dataset-main/cram/CPG123.cram'},
             'CPG456': {2: 'gs://cpg-dataset-main/exome/cram/CPG456.cram'},
         }
         auditor = GenericAuditor(
-            dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
+            dataset='dev', sequencing_type=['genome', 'exome'], file_types=('fastq',)
         )
         auditor.get_gcs_bucket_subdirs_to_search = MagicMock()
         auditor.find_files_in_gcs_buckets_subdirs = MagicMock()
-        auditor.analyses_for_samples_without_crams = MagicMock()
+        auditor.analyses_for_sgs_without_crams = MagicMock()
 
         auditor.get_gcs_bucket_subdirs_to_search.return_value = {
             'cpg-dataset-main': ['cram', 'exome/cram']
@@ -468,9 +603,9 @@ class TestGenericAuditor(unittest.TestCase):
             'gs://cpg-dataset-main/exome/cram/CPG456.cram',
         ]
 
-        result = auditor.get_complete_and_incomplete_samples(
-            sample_internal_to_external_id_map=sample_map,
-            sample_cram_paths=sample_cram_paths,
+        result = auditor.get_complete_and_incomplete_sgs(
+            assay_sg_id_map=assay_sg_id_map,
+            sg_cram_paths=sg_cram_paths,
         )
 
         expected_result = {
@@ -480,17 +615,18 @@ class TestGenericAuditor(unittest.TestCase):
 
         self.assertDictEqual(result, expected_result)
 
-    async def test_check_for_uningested_or_moved_sequences(self):
+    async def test_check_for_uningested_or_moved_assays(self):
         """Test 2 ingested reads, one ingested and moved read, and one uningested read"""
         auditor = GenericAuditor(
             dataset='dev', sequencing_type=['genome'], file_types=('fastq',)
         )
-        seq_reads_sizes = {  # noqa: B006
+        assay_reads_sizes = {  # noqa: B006
             1: [('read1.fq', 10), ('read2.fq', 11), ('dir1/read3.fq', 12)]
         }
-        completed_samples = {'CPG123': [1]}
-        seq_sample_map = {1: 'CPG123'}
-        sample_id_internal_external_map = {'CPG123': 'EXT123'}
+        completed_sgs = {'CPG123': [1]}
+        sg_sample_id_map = {'CPG123': 'EXT123'}
+        assay_sg_id_map = {1: 'CPG123'}
+        sample_internal_external_id_map = {'CPG123': 'EXT123'}
         auditor.find_sequence_files_in_gcs_bucket = MagicMock()
         auditor.find_sequence_files_in_gcs_bucket.return_value = [
             'read1.fq',
@@ -506,27 +642,29 @@ class TestGenericAuditor(unittest.TestCase):
             uningested_sequence_paths,
             sequences_moved_paths,
             _,
-        ) = await auditor.check_for_uningested_or_moved_sequences(
+        ) = await auditor.check_for_uningested_or_moved_assays(
             bucket_name='gs://cpg-test-upload',
-            sequence_filepaths_filesizes=seq_reads_sizes,
-            completed_samples=completed_samples,
-            seq_id_sample_id_map=seq_sample_map,
-            sample_id_internal_external_map=sample_id_internal_external_map,
+            assay_filepaths_filesizes=assay_reads_sizes,
+            completed_sgs=completed_sgs,
+            sg_sample_id_map=sg_sample_id_map,
+            assay_sg_id_map=assay_sg_id_map,
+            sample_internal_external_id_map=sample_internal_external_id_map,
         )
 
-        SequenceReportEntry = namedtuple(
-            'sequence_report_entry',
-            'sample_id sequence_id sequence_file_path analysis_ids',
+        AssayReportEntry = namedtuple(
+            'AssayReportEntry',
+            'sg_id assay_id assay_file_path analysis_ids filesize',
         )
         self.assertEqual(uningested_sequence_paths, {'read4.fq'})
         self.assertEqual(
             sequences_moved_paths,
             [
-                SequenceReportEntry(
-                    sample_id='CPG123',
-                    sequence_id=1,
-                    sequence_file_path='dir2/read3.fq',
+                AssayReportEntry(
+                    sg_id='CPG123',
+                    assay_id=1,
+                    assay_file_path='dir2/read3.fq',
                     analysis_ids=[1],
+                    filesize=12,
                 ),
             ],
         )


### PR DESCRIPTION
I've updated the audit module to account for the SG changes. There will be some more additions to the module in the near future, for now I want to get this base section merged so I can build upon it.

Structurally everything here in the audit module remains the same in terms of how the job gets done, i.e.

1. Iterate through Sequence Groups and find where the Assay read files are located
2. Check which Sequence Groups have completed CRAMs - those that do can have their assay files deleted
3. Create reports in the bucket which detail: 
 - which files can be deleted, 
 - which might need to be ingested, and 
 - which Sequence Groups assays have not yet been aligned into a CRAM.
5. Delete the files from SGs which have completed ingestion and alignment with the `delete_assay_files_from_audit.py` script