### PR TITLE
find analysis runner logs with status unknown

### DIFF
--- a/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
+++ b/web/src/pages/project/AnalysisRunnerView/AnalysisRunnerSummary.tsx
@@ -20,7 +20,7 @@ const PAGE_SIZES = [20, 40, 100, 1000]
 const GET_ANALYSIS_RUNNER_LOGS = gql(`
 query AnalysisRunnerLogs($project_name: String!) {
     project(name: $project_name) {
-        analyses(type: { eq: "analysis-runner" }) {
+        analyses(type: { eq: "analysis-runner" }, status: {eq: UNKNOWN}) {
           author
           id
           meta


### PR DESCRIPTION
Analysis grid logs have `status: unknown` but when the status field is omitted, graphql defaults to `status: completed`.
Specifying `status: unknown` solves this